### PR TITLE
Reinitialize keyboard hook on first idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BeatBind - Spotify Global Hotkeys
 
 [![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/justinknguyen/BeatBind)
-[![version](https://img.shields.io/badge/version-2.0.3-blue)](https://github.com/justinknguyen/BeatBind/releases)
+[![version](https://img.shields.io/badge/version-2.0.4-blue)](https://github.com/justinknguyen/BeatBind/releases)
 [![.NET](https://img.shields.io/badge/.NET-8.0-512BD4)](https://dotnet.microsoft.com/)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/justinknguyen/BeatBind/issues)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)

--- a/src/BeatBind.Presentation/MainForm.cs
+++ b/src/BeatBind.Presentation/MainForm.cs
@@ -15,7 +15,7 @@ namespace BeatBind.Presentation
 {
     public partial class MainForm : MaterialForm
     {
-        public const string CURRENT_VERSION = "2.0.3";
+        public const string CURRENT_VERSION = "2.0.4";
 
         private readonly MaterialSkinManager _materialSkinManager;
         private readonly AuthenticationApplicationService _authenticationService;
@@ -124,6 +124,19 @@ namespace BeatBind.Presentation
 
             // Initialize hotkeys from configuration once the service is set
             _hotkeyApplicationService.InitializeHotkeys();
+
+            // The keyboard hook is installed before Application.Run() starts the message pump.
+            // On login, other programs generate keyboard events during that gap, causing Windows
+            // to time out the hook (LowLevelHooksTimeout). Reinstall it on the first idle tick
+            // after the message loop is fully running so it is guaranteed to be active.
+            System.Windows.Forms.Application.Idle += ReinitializeHookOnFirstIdle;
+        }
+
+        private void ReinitializeHookOnFirstIdle(object? sender, EventArgs e)
+        {
+            System.Windows.Forms.Application.Idle -= ReinitializeHookOnFirstIdle;
+            _hotkeyApplicationService?.Pause();
+            _hotkeyApplicationService?.Resume();
         }
 
         /// <summary>

--- a/src/BeatBind.Tests/Infrastructure/Services/HotkeyServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/HotkeyServiceTests.cs
@@ -111,10 +111,46 @@ namespace BeatBind.Tests.Infrastructure.Services
             _service.IsHookInstalled.Should().BeTrue();
         }
 
+        // Verifies the Pause+Resume cycle used by the startup timing fix in MainForm:
+        // the hook is reinstalled on the first Application.Idle tick to replace any
+        // hook that Windows may have timed out before the message loop started.
+        [Fact]
+        public void PauseThenResume_ShouldReinstallHook()
+        {
+            // Constructor installs hook once (InstallCallCount = 1)
+            _service.Pause();
+            _service.Resume();
+
+            _service.IsHookInstalled.Should().BeTrue();
+            _service.InstallCallCount.Should().Be(2); // ctor + Resume
+            _service.UninstallCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void Resume_WhenHookAlreadyInstalled_ShouldNotInstallAgain()
+        {
+            // Hook is installed from constructor — calling Resume again should be a no-op
+            _service.Resume();
+
+            _service.IsHookInstalled.Should().BeTrue();
+            _service.InstallCallCount.Should().Be(1); // only from ctor
+        }
+
+        [Fact]
+        public void Pause_WhenHookAlreadyPaused_ShouldNotUninstallAgain()
+        {
+            _service.Pause();
+            _service.Pause(); // second call should be a no-op
+
+            _service.UninstallCallCount.Should().Be(1);
+        }
+
         // Testable subclass to bypass P/Invoke
         private class TestableHotkeyService : HotkeyService
         {
             public bool IsHookInstalled { get; private set; }
+            public int InstallCallCount { get; private set; }
+            public int UninstallCallCount { get; private set; }
 
             public TestableHotkeyService(ILogger<HotkeyService> logger)
                 : base(logger)
@@ -124,12 +160,14 @@ namespace BeatBind.Tests.Infrastructure.Services
             protected override IntPtr InstallHook(LowLevelKeyboardProc proc)
             {
                 IsHookInstalled = true;
+                InstallCallCount++;
                 return new IntPtr(123); // Dummy handle
             }
 
             protected override void UninstallHook(IntPtr hookId)
             {
                 IsHookInstalled = false;
+                UninstallCallCount++;
             }
         }
     }


### PR DESCRIPTION
Delay reinstalling the keyboard hook until the application's first idle tick after the message loop starts. Previously the hook was installed before Application.Run(), which could time out (LowLevelHooksTimeout) due to keyboard events generated by other programs during login. This change registers an Application.Idle handler that removes itself and calls Pause/Resume on the hotkey service to reliably reinstall the hook once the message pump is fully running.