### PR TITLE
Beta

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Something isn't working
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: BeatBind version
+      description: Shown in the update banner, or check the release you downloaded.
+      placeholder: "2.1.0"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: "Pressed my Play/Pause hotkey while an ad was playing and ..."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open BeatBind and authenticate
+        2. Set a hotkey for Volume Up
+        3. Press it while ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log file
+      description: |
+        Attach or paste the relevant part of the log from `%APPDATA%\BeatBind\` (paste that path into File Explorer). Logs cover the last 48 hours and record every Spotify command sent — they make most bugs diagnosable without back-and-forth. Remove anything you consider sensitive.
+      render: text
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Windows version, and anything unusual (multiple audio devices, casting to a speaker, Spotify Free vs Premium).
+      placeholder: "Windows 11 23H2, Premium, playing on desktop client"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Heads up: the maintainer has scaled back active development, so features are mostly implemented by community contributors. PRs are very welcome — see [CONTRIBUTING.md](https://github.com/justinknguyen/BeatBind/blob/dev/CONTRIBUTING.md) for a quick-start.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      placeholder: "When I ... I have to ... which is annoying because ..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      placeholder: "Add a hotkey action that ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you be willing to implement this yourself?
+      options:
+        - "Yes, with some pointers"
+        - "Maybe"
+        - "No"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- Thanks for contributing! See CONTRIBUTING.md for the full guide. -->
+
+## What does this PR do?
+
+
+
+## Checklist
+
+- [ ] Targets the `dev` branch
+- [ ] `dotnet build src/BeatBind.sln --configuration Release` succeeds with no new warnings
+- [ ] `dotnet test src/BeatBind.Tests/BeatBind.Tests.csproj` passes
+- [ ] New behavior is covered by tests
+- [ ] No architecture-layer violations (dependencies flow Presentation → Application → Infrastructure → Core only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ CI (`.github/workflows/ci.yml`) runs on pushes/PRs to `dev`: `dotnet restore src
 
 Branch model: `main` is the stable/release branch, `dev` is the active development branch (PRs target `dev`), `beta` auto-publishes a beta GitHub release on every push via `build-and-release.yml`.
 
+Version bump (see CONTRIBUTING.md "Releasing a new version"): update `CURRENT_VERSION` in `src/BeatBind.Presentation/MainForm.cs` (the update checker compares it against the latest GitHub release tag) AND the version badge at the top of `README.md`. Those are the only two locations.
+
 ## Architecture
 
 Clean Architecture, five projects under `src/`, dependencies flow inward only: **Presentation → Application → Infrastructure → Core** (Core has no dependencies on the other layers; Infrastructure and Presentation both depend on Core/Application, never on each other directly).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to BeatBind
+
+Thanks for helping keep BeatBind alive! The maintainer has scaled back active development, so community contributions drive most changes. This guide gets you from clone to merged PR quickly.
+
+## Prerequisites
+
+- **Windows 10/11** — this is a `net8.0-windows` WinForms app with Win32 keyboard hooks. It cannot be built or run on macOS/Linux (you can still read and edit code there; CI builds on `windows-latest`).
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- A [Spotify Developer app](https://developer.spotify.com/dashboard) (Client ID/Secret) to test against the real API — Spotify **Premium** is required for playback commands.
+
+## Build, run, test
+
+All commands from the repo root:
+
+```bash
+dotnet restore src/BeatBind.sln
+dotnet build src/BeatBind.sln --configuration Release
+
+# Run the app
+cd src/BeatBind && dotnet run
+
+# Run all tests
+dotnet test src/BeatBind.Tests/BeatBind.Tests.csproj
+
+# Run a single test class or test
+dotnet test src/BeatBind.Tests/BeatBind.Tests.csproj --filter "FullyQualifiedName~HotkeyServiceTests"
+dotnet test src/BeatBind.Tests/BeatBind.Tests.csproj --filter "DisplayName~PlayPauseAsync_WhenPlaying_ShouldPause"
+```
+
+CI (`.github/workflows/ci.yml`) runs restore → build (Release) → test on every push/PR to `dev`. Run the same sequence locally before opening a PR.
+
+## Branch model
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Stable releases |
+| `dev`  | Active development — **target your PRs here** |
+| `beta` | Every push auto-publishes a beta GitHub release (`build-and-release.yml`) |
+
+## Where things live
+
+Clean Architecture, five projects under `src/`, dependencies flow inward only (Presentation → Application → Infrastructure → Core):
+
+- **`BeatBind.Core`** — entities (`Track`, `Hotkey`, `PlaybackState`, …) and interfaces (`ISpotifyService`, `IHotkeyService`, …). No external dependencies.
+- **`BeatBind.Application`** — `*ApplicationService` classes orchestrating business logic against Core interfaces. This layer owns the playback-state cache that makes hotkeys fast.
+- **`BeatBind.Infrastructure`** — implementations: `SpotifyService` (Web API + token refresh), `AuthenticationService` (OAuth flow), `ConfigurationService` (`%APPDATA%\BeatBind\config.json`), `HotkeyService` (Win32 low-level keyboard hook), `GithubReleaseService`, `StartupService`.
+- **`BeatBind.Presentation`** — WinForms UI (MaterialSkin.2): `MainForm` shell, `Panels/`, `Components/`, `Helpers/`, `Themes/`.
+- **`BeatBind.Tests`** — xUnit + Moq + FluentAssertions, mirrors the layer structure.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for diagrams and [CLAUDE.md](CLAUDE.md) for a condensed map (also used by AI coding assistants).
+
+### Recipes for common changes
+
+- **New Spotify API capability** → add a method to `ISpotifyService` (Core) → implement in `SpotifyService` (Infrastructure) using the shared `SendRequestAsync` helper (it handles auth headers, HTTP/2, and 401 refresh-retry) → call it from the relevant `*ApplicationService` → wire up UI in a Panel.
+- **New hotkey action** → add to the `HotkeyAction` enum (Core) → handle it in `HotkeyApplicationService.ExecuteHotkeyAction` → it appears in `HotkeyEditorDialog` automatically. If it reads playback state, go through `ExecuteWithPlaybackStateAsync` in `MusicControlApplicationService` so it benefits from the cache and lock.
+- **New config option** → extend `ApplicationConfiguration` (Core) → it round-trips through `ConfigurationService` automatically → expose it in `SettingsPanel`.
+
+### Things that bite
+
+- **Spotify's JSON is full of nullable fields** (`item`, `progress_ms`, `device.volume_percent` can all be `null` — during ads, private sessions, casting). Parse with the `GetInt32OrNull`/`GetStringOrEmpty`-style helpers in `SpotifyService`; never `GetProperty(...).GetInt32()` directly.
+- **`MusicControlApplicationService` serializes commands behind `_playbackLock`** and caches playback state for 2 seconds with optimistic updates. Any new command that reads-then-writes playback state must go through the existing helpers, or you'll reintroduce races.
+- **`.Designer.cs` / `InitializeComponent` rules**: no lambdas, ternaries, control flow, or `nameof()` inside generated UI code — see `.github/agents/WinFormsExpert.agent.md`.
+- **Style is enforced by `.editorconfig` as build warnings** — don't introduce new warnings. Highlights: `var` only when the type is apparent from the right-hand side; `_camelCase` for private fields (including `static readonly`); predefined type keywords (`int`, not `Int32`); match the surrounding file's namespace style.
+
+## Debugging user issues
+
+- Config: `%APPDATA%\BeatBind\config.json`
+- Logs: `%APPDATA%\BeatBind\log-*.txt` (rolling, kept 48 hours). Every Spotify API request is logged (`PUT https://api.spotify.com/v1/me/player/pause`), which is usually enough to diagnose "my hotkey did nothing" reports — ask users for this file.
+
+## Releasing a new version
+
+1. Bump `CURRENT_VERSION` in `src/BeatBind.Presentation/MainForm.cs` (the update checker compares this against the latest GitHub release tag).
+2. Update the version badge at the top of `README.md`.
+3. Merge `dev` → `main`, then create a GitHub release with tag `vX.Y.Z` and attach the published build:
+   ```bash
+   dotnet publish src/BeatBind/BeatBind.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+   ```
+
+Version numbers follow [SemVer](https://semver.org/): patch for fixes, minor for new features, major for breaking changes (e.g. config format).
+
+## Pull request checklist
+
+- [ ] Targets `dev`
+- [ ] `dotnet build` succeeds with **no new warnings**
+- [ ] `dotnet test` passes; new behavior has tests
+- [ ] User-facing changes described in the PR body

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BeatBind - Spotify Global Hotkeys
 
 [![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/justinknguyen/BeatBind)
-[![version](https://img.shields.io/badge/version-2.0.4-blue)](https://github.com/justinknguyen/BeatBind/releases)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](https://github.com/justinknguyen/BeatBind/releases)
 [![.NET](https://img.shields.io/badge/.NET-8.0-512BD4)](https://dotnet.microsoft.com/)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/justinknguyen/BeatBind/issues)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
@@ -118,15 +118,12 @@ Logs are saved to `%APPDATA%\BeatBind\`. The application keeps logs for the past
 
 ## Contributing
 
-Contributions are welcome! This project follows Clean Architecture principles.
+Contributions are welcome and drive most changes to this project! **[CONTRIBUTING.md](CONTRIBUTING.md)** has everything you need to get productive quickly: build/test commands, the branch model (PRs target `dev`), an architecture map with recipes for common changes, gotchas that bite newcomers, and the release checklist.
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run tests (`dotnet test`)
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
+2. Create a feature branch off `dev` (`git checkout -b feature/amazing-feature dev`)
+3. Make your changes and run tests (`dotnet test src/BeatBind.Tests/BeatBind.Tests.csproj`)
+4. Open a Pull Request targeting `dev`
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for project structure and [src/README.md](src/README.md) for development setup.
 

--- a/src/BeatBind.Application/Services/MusicControlApplicationService.cs
+++ b/src/BeatBind.Application/Services/MusicControlApplicationService.cs
@@ -6,9 +6,20 @@ namespace BeatBind.Application.Services
 {
     public class MusicControlApplicationService
     {
+        // How long a fetched playback state stays fresh. Within this window,
+        // repeated hotkey presses (e.g. mashing volume up) reuse the cached state
+        // and send only the command request, halving the round trips per press.
+        private static readonly TimeSpan PlaybackCacheDuration = TimeSpan.FromSeconds(2);
+
         private readonly ISpotifyService _spotifyService;
         private readonly IConfigurationService _configurationService;
         private readonly ILogger<MusicControlApplicationService> _logger;
+
+        // Serializes read-modify-write command sequences so rapid presses compute
+        // successive steps (e.g. 50 -> 60 -> 70) instead of racing on the same base value.
+        private readonly SemaphoreSlim _playbackLock = new(1, 1);
+        private PlaybackState? _cachedPlayback;
+        private DateTime _cachedPlaybackAtUtc;
         private int _lastVolume = 50;
 
         /// <summary>
@@ -32,16 +43,31 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState == null)
+                await _playbackLock.WaitAsync();
+                try
                 {
-                    _logger.LogInformation("No active playback, attempting to start playback");
-                    return await _spotifyService.PlayAsync();
-                }
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        _logger.LogInformation("No active playback, attempting to start playback");
+                        return await _spotifyService.PlayAsync();
+                    }
 
-                return playbackState.IsPlaying
-                    ? await _spotifyService.PauseAsync()
-                    : await _spotifyService.PlayAsync();
+                    var success = playbackState.IsPlaying
+                        ? await _spotifyService.PauseAsync()
+                        : await _spotifyService.PlayAsync();
+
+                    if (success)
+                    {
+                        playbackState.IsPlaying = !playbackState.IsPlaying;
+                    }
+
+                    return success;
+                }
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -58,7 +84,12 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                return await _spotifyService.PlayAsync();
+                var result = await _spotifyService.PlayAsync();
+                if (result)
+                {
+                    InvalidatePlaybackCache();
+                }
+                return result;
             }
             catch (Exception ex)
             {
@@ -75,7 +106,12 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                return await _spotifyService.PauseAsync();
+                var result = await _spotifyService.PauseAsync();
+                if (result)
+                {
+                    InvalidatePlaybackCache();
+                }
+                return result;
             }
             catch (Exception ex)
             {
@@ -92,7 +128,12 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                return await _spotifyService.NextTrackAsync();
+                var result = await _spotifyService.NextTrackAsync();
+                if (result)
+                {
+                    InvalidatePlaybackCache();
+                }
+                return result;
             }
             catch (Exception ex)
             {
@@ -111,17 +152,35 @@ namespace BeatBind.Application.Services
             {
                 var config = _configurationService.GetConfiguration();
 
-                if (config.PreviousTrackRewindToStart)
+                await _playbackLock.WaitAsync();
+                try
                 {
-                    var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                    if (playbackState != null && playbackState.ProgressMs > 5000) // 5 seconds
+                    if (config.PreviousTrackRewindToStart)
                     {
-                        // Rewind to start of current track
-                        return await _spotifyService.SeekToPositionAsync(0);
+                        var playbackState = await GetPlaybackStateCachedAsync();
+                        if (playbackState != null && playbackState.ProgressMs > 5000) // 5 seconds
+                        {
+                            // Rewind to start of current track
+                            if (await _spotifyService.SeekToPositionAsync(0))
+                            {
+                                playbackState.ProgressMs = 0;
+                                return true;
+                            }
+                            return false;
+                        }
                     }
-                }
 
-                return await _spotifyService.PreviousTrackAsync();
+                    var result = await _spotifyService.PreviousTrackAsync();
+                    if (result)
+                    {
+                        InvalidatePlaybackCache();
+                    }
+                    return result;
+                }
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -139,13 +198,29 @@ namespace BeatBind.Application.Services
             try
             {
                 var config = _configurationService.GetConfiguration();
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null)
+
+                await _playbackLock.WaitAsync();
+                try
                 {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
                     var newVolume = Math.Min(100, playbackState.Volume + config.VolumeSteps);
-                    return await _spotifyService.SetVolumeAsync(newVolume);
+                    if (!await _spotifyService.SetVolumeAsync(newVolume))
+                    {
+                        return false;
+                    }
+
+                    playbackState.Volume = newVolume;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -163,13 +238,29 @@ namespace BeatBind.Application.Services
             try
             {
                 var config = _configurationService.GetConfiguration();
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null)
+
+                await _playbackLock.WaitAsync();
+                try
                 {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
                     var newVolume = Math.Max(0, playbackState.Volume - config.VolumeSteps);
-                    return await _spotifyService.SetVolumeAsync(newVolume);
+                    if (!await _spotifyService.SetVolumeAsync(newVolume))
+                    {
+                        return false;
+                    }
+
+                    playbackState.Volume = newVolume;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -186,22 +277,40 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null)
+                await _playbackLock.WaitAsync();
+                try
                 {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
+                    int targetVolume;
                     if (playbackState.Volume > 0)
                     {
                         // Muting: save current volume before muting
                         _lastVolume = playbackState.Volume;
-                        return await _spotifyService.SetVolumeAsync(0);
+                        targetVolume = 0;
                     }
                     else
                     {
                         // Unmuting: restore saved volume (don't update _lastVolume)
-                        return await _spotifyService.SetVolumeAsync(_lastVolume);
+                        targetVolume = _lastVolume;
                     }
+
+                    if (!await _spotifyService.SetVolumeAsync(targetVolume))
+                    {
+                        return false;
+                    }
+
+                    playbackState.Volume = targetVolume;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -218,13 +327,28 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null && playbackState.Volume > 0)
+                await _playbackLock.WaitAsync();
+                try
                 {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null || playbackState.Volume <= 0)
+                    {
+                        return false;
+                    }
+
                     _lastVolume = playbackState.Volume;
-                    return await _spotifyService.SetVolumeAsync(0);
+                    if (!await _spotifyService.SetVolumeAsync(0))
+                    {
+                        return false;
+                    }
+
+                    playbackState.Volume = 0;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -241,12 +365,27 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null && playbackState.Volume == 0)
+                await _playbackLock.WaitAsync();
+                try
                 {
-                    return await _spotifyService.SetVolumeAsync(_lastVolume);
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null || playbackState.Volume != 0)
+                    {
+                        return false;
+                    }
+
+                    if (!await _spotifyService.SetVolumeAsync(_lastVolume))
+                    {
+                        return false;
+                    }
+
+                    playbackState.Volume = _lastVolume;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -297,7 +436,12 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                return await _spotifyService.ToggleShuffleAsync();
+                var result = await _spotifyService.ToggleShuffleAsync();
+                if (result)
+                {
+                    InvalidatePlaybackCache();
+                }
+                return result;
             }
             catch (Exception ex)
             {
@@ -314,7 +458,12 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                return await _spotifyService.ToggleRepeatAsync();
+                var result = await _spotifyService.ToggleRepeatAsync();
+                if (result)
+                {
+                    InvalidatePlaybackCache();
+                }
+                return result;
             }
             catch (Exception ex)
             {
@@ -332,13 +481,29 @@ namespace BeatBind.Application.Services
             try
             {
                 var config = _configurationService.GetConfiguration();
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null)
+
+                await _playbackLock.WaitAsync();
+                try
                 {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
                     var newPosition = Math.Min(playbackState.DurationMs, playbackState.ProgressMs + config.SeekMilliseconds);
-                    return await _spotifyService.SeekToPositionAsync(newPosition);
+                    if (!await _spotifyService.SeekToPositionAsync(newPosition))
+                    {
+                        return false;
+                    }
+
+                    playbackState.ProgressMs = newPosition;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -356,13 +521,29 @@ namespace BeatBind.Application.Services
             try
             {
                 var config = _configurationService.GetConfiguration();
-                var playbackState = await _spotifyService.GetCurrentPlaybackAsync();
-                if (playbackState != null)
+
+                await _playbackLock.WaitAsync();
+                try
                 {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
                     var newPosition = Math.Max(0, playbackState.ProgressMs - config.SeekMilliseconds);
-                    return await _spotifyService.SeekToPositionAsync(newPosition);
+                    if (!await _spotifyService.SeekToPositionAsync(newPosition))
+                    {
+                        return false;
+                    }
+
+                    playbackState.ProgressMs = newPosition;
+                    return true;
                 }
-                return false;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -373,6 +554,7 @@ namespace BeatBind.Application.Services
 
         /// <summary>
         /// Retrieves the current playback state including track and device information.
+        /// Always queries the API so UI consumers see fresh data.
         /// </summary>
         /// <returns>The current playback state, or null if unavailable.</returns>
         public async Task<PlaybackState?> GetCurrentPlaybackAsync()
@@ -386,6 +568,35 @@ namespace BeatBind.Application.Services
                 _logger.LogError(ex, "Failed to get current playback state");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Returns the cached playback state if it is still fresh; otherwise fetches
+        /// a new one from the API. Must be called while holding the playback lock.
+        /// Successful commands update the cached state optimistically, so ProgressMs
+        /// may lag real playback by up to the cache duration.
+        /// </summary>
+        /// <returns>The playback state, or null if unavailable.</returns>
+        private async Task<PlaybackState?> GetPlaybackStateCachedAsync()
+        {
+            if (_cachedPlayback != null && DateTime.UtcNow - _cachedPlaybackAtUtc < PlaybackCacheDuration)
+            {
+                return _cachedPlayback;
+            }
+
+            var state = await _spotifyService.GetCurrentPlaybackAsync();
+            _cachedPlayback = state;
+            _cachedPlaybackAtUtc = DateTime.UtcNow;
+            return state;
+        }
+
+        /// <summary>
+        /// Discards the cached playback state after commands that change the track
+        /// or otherwise make the cached snapshot unreliable.
+        /// </summary>
+        private void InvalidatePlaybackCache()
+        {
+            _cachedPlayback = null;
         }
     }
 }

--- a/src/BeatBind.Application/Services/MusicControlApplicationService.cs
+++ b/src/BeatBind.Application/Services/MusicControlApplicationService.cs
@@ -436,12 +436,28 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var result = await _spotifyService.ToggleShuffleAsync();
-                if (result)
+                await _playbackLock.WaitAsync();
+                try
                 {
-                    InvalidatePlaybackCache();
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
+                    var newState = !playbackState.ShuffleState;
+                    if (!await _spotifyService.SetShuffleAsync(newState))
+                    {
+                        return false;
+                    }
+
+                    playbackState.ShuffleState = newState;
+                    return true;
                 }
-                return result;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {
@@ -458,12 +474,34 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var result = await _spotifyService.ToggleRepeatAsync();
-                if (result)
+                await _playbackLock.WaitAsync();
+                try
                 {
-                    InvalidatePlaybackCache();
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
+                    var newMode = playbackState.RepeatState switch
+                    {
+                        RepeatMode.Off => RepeatMode.Context,
+                        RepeatMode.Context => RepeatMode.Track,
+                        _ => RepeatMode.Off
+                    };
+
+                    if (!await _spotifyService.SetRepeatAsync(newMode))
+                    {
+                        return false;
+                    }
+
+                    playbackState.RepeatState = newMode;
+                    return true;
                 }
-                return result;
+                finally
+                {
+                    _playbackLock.Release();
+                }
             }
             catch (Exception ex)
             {

--- a/src/BeatBind.Application/Services/MusicControlApplicationService.cs
+++ b/src/BeatBind.Application/Services/MusicControlApplicationService.cs
@@ -9,14 +9,15 @@ namespace BeatBind.Application.Services
         // How long a fetched playback state stays fresh. Within this window,
         // repeated hotkey presses (e.g. mashing volume up) reuse the cached state
         // and send only the command request, halving the round trips per press.
-        private static readonly TimeSpan PlaybackCacheDuration = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan _playbackCacheDuration = TimeSpan.FromSeconds(2);
 
         private readonly ISpotifyService _spotifyService;
         private readonly IConfigurationService _configurationService;
         private readonly ILogger<MusicControlApplicationService> _logger;
 
-        // Serializes read-modify-write command sequences so rapid presses compute
-        // successive steps (e.g. 50 -> 60 -> 70) instead of racing on the same base value.
+        // Serializes command sequences so rapid presses compute successive steps
+        // (e.g. 50 -> 60 -> 70) instead of racing on the same base value. Every
+        // read or write of _cachedPlayback must happen while holding this lock.
         private readonly SemaphoreSlim _playbackLock = new(1, 1);
         private PlaybackState? _cachedPlayback;
         private DateTime _cachedPlaybackAtUtc;
@@ -53,16 +54,22 @@ namespace BeatBind.Application.Services
                         return await _spotifyService.PlayAsync();
                     }
 
-                    var success = playbackState.IsPlaying
-                        ? await _spotifyService.PauseAsync()
-                        : await _spotifyService.PlayAsync();
-
-                    if (success)
+                    if (await TogglePlaybackAsync(playbackState))
                     {
-                        playbackState.IsPlaying = !playbackState.IsPlaying;
+                        return true;
                     }
 
-                    return success;
+                    // The command can fail because the cached state is stale — e.g.
+                    // playback ended on its own, so pausing was rejected. Refetch
+                    // the real state and retry once
+                    InvalidatePlaybackCache();
+                    playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return await _spotifyService.PlayAsync();
+                    }
+
+                    return await TogglePlaybackAsync(playbackState);
                 }
                 finally
                 {
@@ -80,66 +87,27 @@ namespace BeatBind.Application.Services
         /// Starts playback.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> PlayAsync()
+        public Task<bool> PlayAsync()
         {
-            try
-            {
-                var result = await _spotifyService.PlayAsync();
-                if (result)
-                {
-                    InvalidatePlaybackCache();
-                }
-                return result;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to start playback");
-                return false;
-            }
+            return ExecuteInvalidatingCommandAsync("start playback", _spotifyService.PlayAsync);
         }
 
         /// <summary>
         /// Pauses playback.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> PauseAsync()
+        public Task<bool> PauseAsync()
         {
-            try
-            {
-                var result = await _spotifyService.PauseAsync();
-                if (result)
-                {
-                    InvalidatePlaybackCache();
-                }
-                return result;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to pause playback");
-                return false;
-            }
+            return ExecuteInvalidatingCommandAsync("pause playback", _spotifyService.PauseAsync);
         }
 
         /// <summary>
         /// Skips to the next track in the playback queue.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> NextTrackAsync()
+        public Task<bool> NextTrackAsync()
         {
-            try
-            {
-                var result = await _spotifyService.NextTrackAsync();
-                if (result)
-                {
-                    InvalidatePlaybackCache();
-                }
-                return result;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to skip to next track");
-                return false;
-            }
+            return ExecuteInvalidatingCommandAsync("skip to next track", _spotifyService.NextTrackAsync);
         }
 
         /// <summary>
@@ -150,23 +118,23 @@ namespace BeatBind.Application.Services
         {
             try
             {
-                var config = _configurationService.GetConfiguration();
-
                 await _playbackLock.WaitAsync();
                 try
                 {
+                    var config = _configurationService.GetConfiguration();
                     if (config.PreviousTrackRewindToStart)
                     {
                         var playbackState = await GetPlaybackStateCachedAsync();
                         if (playbackState != null && playbackState.ProgressMs > 5000) // 5 seconds
                         {
                             // Rewind to start of current track
-                            if (await _spotifyService.SeekToPositionAsync(0))
+                            if (!await _spotifyService.SeekToPositionAsync(0))
                             {
-                                playbackState.ProgressMs = 0;
-                                return true;
+                                return false;
                             }
-                            return false;
+
+                            playbackState.ProgressMs = 0;
+                            return true;
                         }
                     }
 
@@ -193,205 +161,78 @@ namespace BeatBind.Application.Services
         /// Increases the playback volume by the configured volume step amount.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> VolumeUpAsync()
+        public Task<bool> VolumeUpAsync()
         {
-            try
-            {
-                var config = _configurationService.GetConfiguration();
-
-                await _playbackLock.WaitAsync();
-                try
-                {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
-
-                    var newVolume = Math.Min(100, playbackState.Volume + config.VolumeSteps);
-                    if (!await _spotifyService.SetVolumeAsync(newVolume))
-                    {
-                        return false;
-                    }
-
-                    playbackState.Volume = newVolume;
-                    return true;
-                }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to increase volume");
-                return false;
-            }
+            return AdjustVolumeAsync("increase volume", direction: +1);
         }
 
         /// <summary>
         /// Decreases the playback volume by the configured volume step amount.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> VolumeDownAsync()
+        public Task<bool> VolumeDownAsync()
         {
-            try
-            {
-                var config = _configurationService.GetConfiguration();
-
-                await _playbackLock.WaitAsync();
-                try
-                {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
-
-                    var newVolume = Math.Max(0, playbackState.Volume - config.VolumeSteps);
-                    if (!await _spotifyService.SetVolumeAsync(newVolume))
-                    {
-                        return false;
-                    }
-
-                    playbackState.Volume = newVolume;
-                    return true;
-                }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to decrease volume");
-                return false;
-            }
+            return AdjustVolumeAsync("decrease volume", direction: -1);
         }
 
         /// <summary>
         /// Toggles mute state by setting volume to 0 or restoring the previous volume level.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> ToggleMuteAsync()
+        public Task<bool> ToggleMuteAsync()
         {
-            try
+            return ExecuteWithPlaybackStateAsync("toggle mute", async playbackState =>
             {
-                await _playbackLock.WaitAsync();
-                try
+                if (playbackState.Volume is not int volume)
                 {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
-
-                    int targetVolume;
-                    if (playbackState.Volume > 0)
-                    {
-                        // Muting: save current volume before muting
-                        _lastVolume = playbackState.Volume;
-                        targetVolume = 0;
-                    }
-                    else
-                    {
-                        // Unmuting: restore saved volume (don't update _lastVolume)
-                        targetVolume = _lastVolume;
-                    }
-
-                    if (!await _spotifyService.SetVolumeAsync(targetVolume))
-                    {
-                        return false;
-                    }
-
-                    playbackState.Volume = targetVolume;
-                    return true;
+                    return false;
                 }
-                finally
+
+                if (volume > 0)
                 {
-                    _playbackLock.Release();
+                    // Muting: save current volume before muting
+                    _lastVolume = volume;
+                    return await SetVolumeAndCacheAsync(playbackState, 0);
                 }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to toggle mute");
-                return false;
-            }
+
+                // Unmuting: restore saved volume (don't update _lastVolume)
+                return await SetVolumeAndCacheAsync(playbackState, _lastVolume);
+            });
         }
 
         /// <summary>
         /// Mutes the volume by setting it to 0.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> MuteAsync()
+        public Task<bool> MuteAsync()
         {
-            try
+            return ExecuteWithPlaybackStateAsync("mute", async playbackState =>
             {
-                await _playbackLock.WaitAsync();
-                try
+                if (playbackState.Volume is not int volume || volume <= 0)
                 {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null || playbackState.Volume <= 0)
-                    {
-                        return false;
-                    }
-
-                    _lastVolume = playbackState.Volume;
-                    if (!await _spotifyService.SetVolumeAsync(0))
-                    {
-                        return false;
-                    }
-
-                    playbackState.Volume = 0;
-                    return true;
+                    return false;
                 }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to mute");
-                return false;
-            }
+
+                _lastVolume = volume;
+                return await SetVolumeAndCacheAsync(playbackState, 0);
+            });
         }
 
         /// <summary>
         /// Unmutes the volume by restoring the previous volume level.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> UnmuteAsync()
+        public Task<bool> UnmuteAsync()
         {
-            try
+            return ExecuteWithPlaybackStateAsync("unmute", async playbackState =>
             {
-                await _playbackLock.WaitAsync();
-                try
+                if (playbackState.Volume != 0)
                 {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null || playbackState.Volume != 0)
-                    {
-                        return false;
-                    }
-
-                    if (!await _spotifyService.SetVolumeAsync(_lastVolume))
-                    {
-                        return false;
-                    }
-
-                    playbackState.Volume = _lastVolume;
-                    return true;
+                    return false;
                 }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to unmute");
-                return false;
-            }
+
+                return await SetVolumeAndCacheAsync(playbackState, _lastVolume);
+            });
         }
 
         /// <summary>
@@ -432,162 +273,62 @@ namespace BeatBind.Application.Services
         /// Toggles shuffle mode for the current playback.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> ToggleShuffleAsync()
+        public Task<bool> ToggleShuffleAsync()
         {
-            try
+            return ExecuteWithPlaybackStateAsync("toggle shuffle", async playbackState =>
             {
-                await _playbackLock.WaitAsync();
-                try
+                var newState = !playbackState.ShuffleState;
+                if (!await _spotifyService.SetShuffleAsync(newState))
                 {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
-
-                    var newState = !playbackState.ShuffleState;
-                    if (!await _spotifyService.SetShuffleAsync(newState))
-                    {
-                        return false;
-                    }
-
-                    playbackState.ShuffleState = newState;
-                    return true;
+                    return false;
                 }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to toggle shuffle");
-                return false;
-            }
+
+                playbackState.ShuffleState = newState;
+                return true;
+            });
         }
 
         /// <summary>
         /// Cycles through repeat modes: Off -> Context -> Track -> Off.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> ToggleRepeatAsync()
+        public Task<bool> ToggleRepeatAsync()
         {
-            try
+            return ExecuteWithPlaybackStateAsync("toggle repeat", async playbackState =>
             {
-                await _playbackLock.WaitAsync();
-                try
+                var newMode = playbackState.RepeatState switch
                 {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
+                    RepeatMode.Off => RepeatMode.Context,
+                    RepeatMode.Context => RepeatMode.Track,
+                    _ => RepeatMode.Off
+                };
 
-                    var newMode = playbackState.RepeatState switch
-                    {
-                        RepeatMode.Off => RepeatMode.Context,
-                        RepeatMode.Context => RepeatMode.Track,
-                        _ => RepeatMode.Off
-                    };
-
-                    if (!await _spotifyService.SetRepeatAsync(newMode))
-                    {
-                        return false;
-                    }
-
-                    playbackState.RepeatState = newMode;
-                    return true;
-                }
-                finally
+                if (!await _spotifyService.SetRepeatAsync(newMode))
                 {
-                    _playbackLock.Release();
+                    return false;
                 }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to toggle repeat");
-                return false;
-            }
+
+                playbackState.RepeatState = newMode;
+                return true;
+            });
         }
 
         /// <summary>
         /// Seeks forward in the current track by the configured seek milliseconds amount.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> SeekForwardAsync()
+        public Task<bool> SeekForwardAsync()
         {
-            try
-            {
-                var config = _configurationService.GetConfiguration();
-
-                await _playbackLock.WaitAsync();
-                try
-                {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
-
-                    var newPosition = Math.Min(playbackState.DurationMs, playbackState.ProgressMs + config.SeekMilliseconds);
-                    if (!await _spotifyService.SeekToPositionAsync(newPosition))
-                    {
-                        return false;
-                    }
-
-                    playbackState.ProgressMs = newPosition;
-                    return true;
-                }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to seek forward");
-                return false;
-            }
+            return SeekByAsync("seek forward", direction: +1);
         }
 
         /// <summary>
         /// Seeks backward in the current track by the configured seek milliseconds amount.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
-        public async Task<bool> SeekBackwardAsync()
+        public Task<bool> SeekBackwardAsync()
         {
-            try
-            {
-                var config = _configurationService.GetConfiguration();
-
-                await _playbackLock.WaitAsync();
-                try
-                {
-                    var playbackState = await GetPlaybackStateCachedAsync();
-                    if (playbackState == null)
-                    {
-                        return false;
-                    }
-
-                    var newPosition = Math.Max(0, playbackState.ProgressMs - config.SeekMilliseconds);
-                    if (!await _spotifyService.SeekToPositionAsync(newPosition))
-                    {
-                        return false;
-                    }
-
-                    playbackState.ProgressMs = newPosition;
-                    return true;
-                }
-                finally
-                {
-                    _playbackLock.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to seek backward");
-                return false;
-            }
+            return SeekByAsync("seek backward", direction: -1);
         }
 
         /// <summary>
@@ -609,6 +350,140 @@ namespace BeatBind.Application.Services
         }
 
         /// <summary>
+        /// Sends play or pause based on the given state and flips the cached
+        /// IsPlaying flag on success.
+        /// </summary>
+        private async Task<bool> TogglePlaybackAsync(PlaybackState playbackState)
+        {
+            var success = playbackState.IsPlaying
+                ? await _spotifyService.PauseAsync()
+                : await _spotifyService.PlayAsync();
+
+            if (success)
+            {
+                playbackState.IsPlaying = !playbackState.IsPlaying;
+            }
+
+            return success;
+        }
+
+        /// <summary>
+        /// Changes the volume by the configured step in the given direction.
+        /// Does nothing when the device does not report its volume — an absolute
+        /// step from an assumed level could yank the real volume wildly.
+        /// </summary>
+        private Task<bool> AdjustVolumeAsync(string operation, int direction)
+        {
+            return ExecuteWithPlaybackStateAsync(operation, async playbackState =>
+            {
+                if (playbackState.Volume is not int volume)
+                {
+                    return false;
+                }
+
+                var steps = _configurationService.GetConfiguration().VolumeSteps;
+                var newVolume = Math.Clamp(volume + direction * steps, 0, 100);
+                return await SetVolumeAndCacheAsync(playbackState, newVolume);
+            });
+        }
+
+        /// <summary>
+        /// Seeks by the configured amount in the given direction, clamped to the track bounds.
+        /// </summary>
+        private Task<bool> SeekByAsync(string operation, int direction)
+        {
+            return ExecuteWithPlaybackStateAsync(operation, async playbackState =>
+            {
+                var seekMs = _configurationService.GetConfiguration().SeekMilliseconds;
+                var newPosition = Math.Clamp(playbackState.ProgressMs + direction * seekMs, 0, playbackState.DurationMs);
+                if (!await _spotifyService.SeekToPositionAsync(newPosition))
+                {
+                    return false;
+                }
+
+                playbackState.ProgressMs = newPosition;
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Sets the volume and mirrors the new value into the cached playback state on success.
+        /// </summary>
+        private async Task<bool> SetVolumeAndCacheAsync(PlaybackState playbackState, int targetVolume)
+        {
+            if (!await _spotifyService.SetVolumeAsync(targetVolume))
+            {
+                return false;
+            }
+
+            playbackState.Volume = targetVolume;
+            return true;
+        }
+
+        /// <summary>
+        /// Runs an action against the (possibly cached) playback state while holding
+        /// the playback lock; returns false when no playback state is available.
+        /// Exceptions are logged with the operation name and reported as failure.
+        /// </summary>
+        private async Task<bool> ExecuteWithPlaybackStateAsync(string operation, Func<PlaybackState, Task<bool>> action)
+        {
+            try
+            {
+                await _playbackLock.WaitAsync();
+                try
+                {
+                    var playbackState = await GetPlaybackStateCachedAsync();
+                    if (playbackState == null)
+                    {
+                        return false;
+                    }
+
+                    return await action(playbackState);
+                }
+                finally
+                {
+                    _playbackLock.Release();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to {Operation}", operation);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Runs a command that changes what is playing, invalidating the cached
+        /// playback state on success. Holds the playback lock so the invalidation
+        /// cannot race a concurrent cached read.
+        /// </summary>
+        private async Task<bool> ExecuteInvalidatingCommandAsync(string operation, Func<Task<bool>> command)
+        {
+            try
+            {
+                await _playbackLock.WaitAsync();
+                try
+                {
+                    var result = await command();
+                    if (result)
+                    {
+                        InvalidatePlaybackCache();
+                    }
+                    return result;
+                }
+                finally
+                {
+                    _playbackLock.Release();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to {Operation}", operation);
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Returns the cached playback state if it is still fresh; otherwise fetches
         /// a new one from the API. Must be called while holding the playback lock.
         /// Successful commands update the cached state optimistically, so ProgressMs
@@ -617,7 +492,7 @@ namespace BeatBind.Application.Services
         /// <returns>The playback state, or null if unavailable.</returns>
         private async Task<PlaybackState?> GetPlaybackStateCachedAsync()
         {
-            if (_cachedPlayback != null && DateTime.UtcNow - _cachedPlaybackAtUtc < PlaybackCacheDuration)
+            if (_cachedPlayback != null && DateTime.UtcNow - _cachedPlaybackAtUtc < _playbackCacheDuration)
             {
                 return _cachedPlayback;
             }
@@ -630,7 +505,8 @@ namespace BeatBind.Application.Services
 
         /// <summary>
         /// Discards the cached playback state after commands that change the track
-        /// or otherwise make the cached snapshot unreliable.
+        /// or otherwise make the cached snapshot unreliable. Must be called while
+        /// holding the playback lock.
         /// </summary>
         private void InvalidatePlaybackCache()
         {

--- a/src/BeatBind.Core/Entities/PlaybackState.cs
+++ b/src/BeatBind.Core/Entities/PlaybackState.cs
@@ -5,7 +5,12 @@ namespace BeatBind.Core.Entities
         public bool IsPlaying { get; set; }
         public bool ShuffleState { get; set; }
         public RepeatMode RepeatState { get; set; }
-        public int Volume { get; set; }
+
+        /// <summary>
+        /// Device volume 0-100, or null when the device does not report a volume
+        /// (Spotify returns volume_percent: null for some devices and sessions).
+        /// </summary>
+        public int? Volume { get; set; }
         public int ProgressMs { get; set; }
         public int DurationMs { get; set; }
         public Track? CurrentTrack { get; set; }

--- a/src/BeatBind.Core/Interfaces/IAuthenticationService.cs
+++ b/src/BeatBind.Core/Interfaces/IAuthenticationService.cs
@@ -4,6 +4,12 @@ namespace BeatBind.Core.Interfaces
 {
     public interface IAuthenticationService
     {
+        /// <summary>
+        /// Raised whenever new authentication tokens are saved, so long-lived
+        /// consumers (e.g. the Spotify service) can adopt them immediately.
+        /// </summary>
+        event EventHandler<AuthenticationResult>? AuthenticationSaved;
+
         Task<AuthenticationResult> AuthenticateAsync();
         Task<AuthenticationResult> RefreshTokenAsync(string refreshToken);
         bool IsTokenValid(AuthenticationResult authResult);

--- a/src/BeatBind.Core/Interfaces/ISpotifyService.cs
+++ b/src/BeatBind.Core/Interfaces/ISpotifyService.cs
@@ -15,8 +15,8 @@ namespace BeatBind.Core.Interfaces
         Task<bool> NextTrackAsync();
         Task<bool> PreviousTrackAsync();
         Task<bool> SetVolumeAsync(int volume);
-        Task<bool> ToggleShuffleAsync();
-        Task<bool> ToggleRepeatAsync();
+        Task<bool> SetShuffleAsync(bool state);
+        Task<bool> SetRepeatAsync(RepeatMode mode);
         Task<bool> SaveCurrentTrackAsync();
         Task<bool> RemoveCurrentTrackAsync();
         Task<bool> SeekToPositionAsync(int positionMs);

--- a/src/BeatBind.Infrastructure/Services/AuthenticationService.cs
+++ b/src/BeatBind.Infrastructure/Services/AuthenticationService.cs
@@ -14,16 +14,18 @@ namespace BeatBind.Infrastructure.Services
     {
         // Treat tokens as expired slightly early so a request sent close to the
         // boundary doesn't go out with a token that is dead on arrival.
-        private static readonly TimeSpan TokenExpiryMargin = TimeSpan.FromSeconds(60);
+        private static readonly TimeSpan _tokenExpiryMargin = TimeSpan.FromSeconds(60);
 
         // How long to wait for the user to complete the browser authorization
         // before giving up and releasing the callback listener.
-        private static readonly TimeSpan CallbackTimeout = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan _callbackTimeout = TimeSpan.FromMinutes(5);
 
         private readonly ILogger<AuthenticationService> _logger;
         private readonly IConfigurationService _configurationService;
         private readonly HttpClient _httpClient;
         private HttpListener? _httpListener;
+
+        public event EventHandler<AuthenticationResult>? AuthenticationSaved;
 
         /// <summary>
         /// Initializes a new instance of the AuthenticationService class.
@@ -159,7 +161,7 @@ namespace BeatBind.Infrastructure.Services
         {
             return authResult != null &&
                    !string.IsNullOrEmpty(authResult.AccessToken) &&
-                   DateTime.UtcNow < authResult.ExpiresAt - TokenExpiryMargin;
+                   DateTime.UtcNow < authResult.ExpiresAt - _tokenExpiryMargin;
         }
 
         /// <summary>
@@ -209,6 +211,11 @@ namespace BeatBind.Infrastructure.Services
                 _configurationService.SaveConfiguration(config);
 
                 _logger.LogInformation("Authentication tokens saved successfully");
+
+                // Let long-lived consumers (the Spotify service) adopt the new
+                // tokens immediately — a UI re-auth to a different account must
+                // not leave hotkeys running on the old account's still-valid token
+                AuthenticationSaved?.Invoke(this, authResult);
             }
             catch (Exception ex)
             {
@@ -259,7 +266,10 @@ namespace BeatBind.Infrastructure.Services
                 ["response_type"] = "code",
                 ["redirect_uri"] = redirectUri,
                 ["state"] = state,
-                ["scope"] = scopes
+                ["scope"] = scopes,
+                // Always show the account/consent dialog so users can switch
+                // Spotify accounts or re-consent from within the app
+                ["show_dialog"] = "true"
             };
 
             var query = string.Join("&", parameters.AllKeys.Select(key => $"{key}={HttpUtility.UrlEncode(parameters[key])}"));
@@ -299,7 +309,7 @@ namespace BeatBind.Infrastructure.Services
             try
             {
                 var contextTask = _httpListener!.GetContextAsync();
-                var completedTask = await Task.WhenAny(contextTask, Task.Delay(CallbackTimeout));
+                var completedTask = await Task.WhenAny(contextTask, Task.Delay(_callbackTimeout));
 
                 if (completedTask != contextTask)
                 {
@@ -307,7 +317,7 @@ namespace BeatBind.Infrastructure.Services
                     // the fault GetContextAsync raises when the caller closes the
                     // listener so it doesn't surface as an unobserved task exception.
                     _ = contextTask.ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted);
-                    _logger.LogWarning("Timed out waiting for the authorization callback after {Timeout}", CallbackTimeout);
+                    _logger.LogWarning("Timed out waiting for the authorization callback after {Timeout}", _callbackTimeout);
                     return new AuthenticationResult { Success = false, Error = "Timed out waiting for the authorization callback. Please try again." };
                 }
 

--- a/src/BeatBind.Infrastructure/Services/AuthenticationService.cs
+++ b/src/BeatBind.Infrastructure/Services/AuthenticationService.cs
@@ -12,6 +12,14 @@ namespace BeatBind.Infrastructure.Services
 {
     public class AuthenticationService : IAuthenticationService
     {
+        // Treat tokens as expired slightly early so a request sent close to the
+        // boundary doesn't go out with a token that is dead on arrival.
+        private static readonly TimeSpan TokenExpiryMargin = TimeSpan.FromSeconds(60);
+
+        // How long to wait for the user to complete the browser authorization
+        // before giving up and releasing the callback listener.
+        private static readonly TimeSpan CallbackTimeout = TimeSpan.FromMinutes(5);
+
         private readonly ILogger<AuthenticationService> _logger;
         private readonly IConfigurationService _configurationService;
         private readonly HttpClient _httpClient;
@@ -82,8 +90,7 @@ namespace BeatBind.Infrastructure.Services
             }
             finally
             {
-                _httpListener?.Stop();
-                _httpListener?.Close();
+                StopCallbackListener();
             }
         }
 
@@ -152,7 +159,7 @@ namespace BeatBind.Infrastructure.Services
         {
             return authResult != null &&
                    !string.IsNullOrEmpty(authResult.AccessToken) &&
-                   DateTime.UtcNow < authResult.ExpiresAt;
+                   DateTime.UtcNow < authResult.ExpiresAt - TokenExpiryMargin;
         }
 
         /// <summary>
@@ -218,6 +225,10 @@ namespace BeatBind.Infrastructure.Services
         {
             try
             {
+                // Release any listener left over from a previous attempt so a
+                // second authentication doesn't fail on the occupied prefix
+                StopCallbackListener();
+
                 _httpListener = new HttpListener();
                 _httpListener.Prefixes.Add(redirectUri.EndsWith('/') ? redirectUri : redirectUri + "/");
                 _httpListener.Start();
@@ -248,8 +259,7 @@ namespace BeatBind.Infrastructure.Services
                 ["response_type"] = "code",
                 ["redirect_uri"] = redirectUri,
                 ["state"] = state,
-                ["scope"] = scopes,
-                ["show_dialog"] = "true"
+                ["scope"] = scopes
             };
 
             var query = string.Join("&", parameters.AllKeys.Select(key => $"{key}={HttpUtility.UrlEncode(parameters[key])}"));
@@ -262,11 +272,46 @@ namespace BeatBind.Infrastructure.Services
         /// </summary>
         /// <param name="expectedState">The expected state value for validation.</param>
         /// <returns>An AuthenticationResult containing the authorization code or error information.</returns>
+        /// <summary>
+        /// Stops and releases the callback listener if one is active.
+        /// </summary>
+        private void StopCallbackListener()
+        {
+            if (_httpListener == null)
+            {
+                return;
+            }
+
+            try
+            {
+                _httpListener.Close();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error stopping callback listener");
+            }
+
+            _httpListener = null;
+        }
+
         private async Task<AuthenticationResult> WaitForCallbackAsync(string expectedState)
         {
             try
             {
-                var context = await _httpListener!.GetContextAsync();
+                var contextTask = _httpListener!.GetContextAsync();
+                var completedTask = await Task.WhenAny(contextTask, Task.Delay(CallbackTimeout));
+
+                if (completedTask != contextTask)
+                {
+                    // The user likely closed the browser without authorizing. Observe
+                    // the fault GetContextAsync raises when the caller closes the
+                    // listener so it doesn't surface as an unobserved task exception.
+                    _ = contextTask.ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted);
+                    _logger.LogWarning("Timed out waiting for the authorization callback after {Timeout}", CallbackTimeout);
+                    return new AuthenticationResult { Success = false, Error = "Timed out waiting for the authorization callback. Please try again." };
+                }
+
+                var context = await contextTask;
                 var request = context.Request;
                 var response = context.Response;
 

--- a/src/BeatBind.Infrastructure/Services/ConfigurationService.cs
+++ b/src/BeatBind.Infrastructure/Services/ConfigurationService.cs
@@ -131,6 +131,40 @@ namespace BeatBind.Infrastructure.Services
         }
 
         /// <summary>
+        /// Assigns fresh IDs to hotkeys with missing (0/negative) or duplicate IDs so
+        /// entries from hand-edited or legacy configs cannot collide — the ID keys
+        /// both the UI list and the hotkey registration, and a collision silently
+        /// drops a hotkey.
+        /// </summary>
+        private void NormalizeHotkeyIds()
+        {
+            if (_config.Hotkeys.Count == 0)
+            {
+                return;
+            }
+
+            var seenIds = new HashSet<int>();
+            var nextId = Math.Max(0, _config.Hotkeys.Max(h => h.Id)) + 1;
+            var changed = false;
+
+            foreach (var hotkey in _config.Hotkeys)
+            {
+                if (hotkey.Id <= 0 || !seenIds.Add(hotkey.Id))
+                {
+                    hotkey.Id = nextId++;
+                    seenIds.Add(hotkey.Id);
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                _logger.LogInformation("Reassigned missing or duplicate hotkey IDs in configuration");
+                SaveConfiguration(_config);
+            }
+        }
+
+        /// <summary>
         /// Ensures that the configuration directory exists, creating it if necessary.
         /// </summary>
         private void EnsureConfigDirectoryExists()
@@ -157,6 +191,7 @@ namespace BeatBind.Infrastructure.Services
                     if (config != null)
                     {
                         _config = config;
+                        NormalizeHotkeyIds();
                         _logger.LogInformation("Configuration loaded from {ConfigPath}", _configPath);
                     }
                 }

--- a/src/BeatBind.Infrastructure/Services/HotkeyService.cs
+++ b/src/BeatBind.Infrastructure/Services/HotkeyService.cs
@@ -37,6 +37,9 @@ namespace BeatBind.Infrastructure.Services
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern IntPtr GetModuleHandle(string lpModuleName);
 
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
         protected delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
 
         public event EventHandler<Hotkey>? HotkeyPressed;
@@ -213,26 +216,78 @@ namespace BeatBind.Infrastructure.Services
 
                 if (wParam == (IntPtr)WM_KEYDOWN || wParam == (IntPtr)WM_SYSKEYDOWN)
                 {
-                    _pressedKeys.Add(vkCode);
-
-                    // Check if this key press triggers a hotkey
-                    bool hotkeyTriggered = CheckHotkeys();
-
                     // If a hotkey was triggered, suppress the key event from propagating
-                    if (hotkeyTriggered)
+                    if (ProcessKeyDown(vkCode))
                     {
                         return (IntPtr)1;
                     }
                 }
                 else if (wParam == (IntPtr)WM_KEYUP || wParam == (IntPtr)WM_SYSKEYUP)
                 {
-                    _pressedKeys.Remove(vkCode);
-                    ClearInactiveHotkeys();
+                    ProcessKeyUp(vkCode);
                 }
             }
 
             // Allow the key event to propagate if no hotkey was triggered
             return CallNextHookEx(_hookId, nCode, wParam, lParam);
+        }
+
+        /// <summary>
+        /// Records a key press, prunes stale keys, and checks for hotkey matches.
+        /// </summary>
+        /// <param name="vkCode">The virtual key code of the pressed key.</param>
+        /// <returns>True if a hotkey was triggered (the key event should be suppressed); otherwise, false.</returns>
+        protected bool ProcessKeyDown(int vkCode)
+        {
+            PruneReleasedKeys(vkCode);
+            _pressedKeys.Add(vkCode);
+
+            return CheckHotkeys();
+        }
+
+        /// <summary>
+        /// Records a key release and clears hotkeys whose keys are no longer held.
+        /// </summary>
+        /// <param name="vkCode">The virtual key code of the released key.</param>
+        protected void ProcessKeyUp(int vkCode)
+        {
+            _pressedKeys.Remove(vkCode);
+            ClearInactiveHotkeys();
+        }
+
+        /// <summary>
+        /// Removes keys from the pressed set that the OS reports as no longer held.
+        /// Key-up events are lost whenever Windows switches to the secure desktop
+        /// (Win+L lock, Ctrl+Alt+Del, UAC prompts) because low-level hooks receive
+        /// no events there — e.g. the Win key from Win+L would otherwise stay
+        /// "pressed" forever and block all hotkey matching until restart.
+        /// </summary>
+        /// <param name="currentVkCode">The key being processed right now. Excluded from
+        /// pruning: the OS input state is not yet updated for the current event, and
+        /// events this hook suppressed never reach the OS input state at all.</param>
+        private void PruneReleasedKeys(int currentVkCode)
+        {
+            if (_pressedKeys.Count == 0)
+            {
+                return;
+            }
+
+            int removed = _pressedKeys.RemoveWhere(vk => vk != currentVkCode && !IsKeyDownInOS(vk));
+            if (removed > 0)
+            {
+                ClearInactiveHotkeys();
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the OS considers the given key physically held down.
+        /// Virtual so tests can simulate OS key state without P/Invoke.
+        /// </summary>
+        /// <param name="vkCode">The virtual key code to check.</param>
+        /// <returns>True if the key is currently down; otherwise, false.</returns>
+        protected virtual bool IsKeyDownInOS(int vkCode)
+        {
+            return (GetAsyncKeyState(vkCode) & 0x8000) != 0;
         }
 
         /// <summary>

--- a/src/BeatBind.Infrastructure/Services/HotkeyService.cs
+++ b/src/BeatBind.Infrastructure/Services/HotkeyService.cs
@@ -159,6 +159,15 @@ namespace BeatBind.Infrastructure.Services
         {
             if (_hookId == IntPtr.Zero)
             {
+                // Keyups missed while the hook was uninstalled (sleep/resume, hook
+                // timeouts) would otherwise leave phantom pressed keys that block
+                // hotkey matching until the user presses the stuck key again
+                _pressedKeys.Clear();
+                lock (_activeLock)
+                {
+                    _activeHotkeys.Clear();
+                }
+
                 _hookId = InstallHook(_hookCallback);
                 if (_hookId == IntPtr.Zero)
                     _logger.LogError("Keyboard hook failed to resume (SetWindowsHookEx returned null)");

--- a/src/BeatBind.Infrastructure/Services/SpotifyService.cs
+++ b/src/BeatBind.Infrastructure/Services/SpotifyService.cs
@@ -12,6 +12,10 @@ namespace BeatBind.Infrastructure.Services
         private readonly ILogger<SpotifyService> _logger;
         private readonly IAuthenticationService _authenticationService;
 
+        // Serializes token refreshes so concurrent hotkey presses don't each
+        // spend the same refresh token independently.
+        private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
         private AuthenticationResult? _currentAuth;
 
         /// <summary>
@@ -31,42 +35,33 @@ namespace BeatBind.Infrastructure.Services
 
             // Try to load stored authentication on startup
             LoadStoredAuthentication();
+
+            if (_currentAuth != null && !_authenticationService.IsTokenValid(_currentAuth))
+            {
+                // Expired but refreshable: refresh in the background so the first
+                // hotkey press doesn't pay for the token round trip. This is safe to
+                // race with API calls because EnsureValidTokenAsync serializes with it
+                // through the refresh lock.
+                _ = Task.Run(() => EnsureValidTokenAsync());
+            }
         }
 
         /// <summary>
-        /// Loads and validates stored authentication tokens from storage.
-        /// Attempts to refresh expired tokens if a refresh token is available.
+        /// Loads stored authentication tokens from storage into the current session.
+        /// The tokens may be expired; EnsureValidTokenAsync refreshes them on demand.
         /// </summary>
         private void LoadStoredAuthentication()
         {
             try
             {
                 var storedAuth = _authenticationService.GetStoredAuthentication();
-                if (storedAuth != null && _authenticationService.IsTokenValid(storedAuth))
+                if (storedAuth != null)
                 {
                     _currentAuth = storedAuth;
-                    _logger.LogInformation("Loaded valid stored authentication");
-                }
-                else if (storedAuth != null && !string.IsNullOrEmpty(storedAuth.RefreshToken))
-                {
-                    // Try to refresh the token if we have a refresh token
-                    _ = Task.Run(async () =>
+                    if (_authenticationService.IsTokenValid(storedAuth))
                     {
-                        try
-                        {
-                            var refreshedAuth = await _authenticationService.RefreshTokenAsync(storedAuth.RefreshToken);
-                            if (refreshedAuth.Success)
-                            {
-                                _currentAuth = refreshedAuth;
-                                _authenticationService.SaveAuthentication(refreshedAuth);
-                                _logger.LogInformation("Successfully refreshed stored authentication");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, "Failed to refresh stored authentication");
-                        }
-                    });
+                        _logger.LogInformation("Loaded valid stored authentication");
+                    }
                 }
             }
             catch (Exception ex)
@@ -116,8 +111,19 @@ namespace BeatBind.Infrastructure.Services
         /// Saves the new tokens to storage upon successful refresh.
         /// </summary>
         /// <returns>True if the token was successfully refreshed; otherwise, false.</returns>
-        public async Task<bool> RefreshTokenAsync()
+        public Task<bool> RefreshTokenAsync()
         {
+            return RefreshTokenCoreAsync(force: true);
+        }
+
+        /// <summary>
+        /// Refreshes the access token while holding the refresh lock.
+        /// </summary>
+        /// <param name="force">When false, skips the refresh if another caller already refreshed the token.</param>
+        /// <returns>True if a valid token is available after the call; otherwise, false.</returns>
+        private async Task<bool> RefreshTokenCoreAsync(bool force)
+        {
+            await _refreshLock.WaitAsync();
             try
             {
                 if (_currentAuth == null || string.IsNullOrEmpty(_currentAuth.RefreshToken))
@@ -125,21 +131,35 @@ namespace BeatBind.Infrastructure.Services
                     return false;
                 }
 
-                _currentAuth = await _authenticationService.RefreshTokenAsync(_currentAuth.RefreshToken);
-
-                if (_currentAuth.Success)
+                if (!force && _authenticationService.IsTokenValid(_currentAuth))
                 {
-                    // Save the refreshed tokens
-                    _authenticationService.SaveAuthentication(_currentAuth);
-                    _logger.LogInformation("Successfully refreshed and saved authentication tokens");
+                    // Another caller refreshed while we waited on the lock
+                    return true;
                 }
 
-                return _currentAuth.Success;
+                var refreshedAuth = await _authenticationService.RefreshTokenAsync(_currentAuth.RefreshToken);
+
+                if (refreshedAuth != null && refreshedAuth.Success)
+                {
+                    // Only replace the current tokens on success so a transient failure
+                    // doesn't wipe the refresh token and break the session until restart
+                    _currentAuth = refreshedAuth;
+                    _authenticationService.SaveAuthentication(refreshedAuth);
+                    _logger.LogInformation("Successfully refreshed and saved authentication tokens");
+                    return true;
+                }
+
+                _logger.LogWarning("Token refresh failed: {Error}", refreshedAuth?.Error);
+                return false;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error refreshing token");
                 return false;
+            }
+            finally
+            {
+                _refreshLock.Release();
             }
         }
 
@@ -151,17 +171,12 @@ namespace BeatBind.Infrastructure.Services
         {
             try
             {
-                if (!await EnsureValidTokenAsync())
+                var url = "https://api.spotify.com/v1/me/player";
+                var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Get, url));
+                if (response == null)
                 {
                     return null;
                 }
-
-                var url = "https://api.spotify.com/v1/me/player";
-                _logger.LogInformation("GET {Url}", url);
-                var request = new HttpRequestMessage(HttpMethod.Get, url);
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
-
-                var response = await _httpClient.SendAsync(request);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
                 {
@@ -192,44 +207,26 @@ namespace BeatBind.Infrastructure.Services
         {
             try
             {
-                if (!await EnsureValidTokenAsync())
+                var url = "https://api.spotify.com/v1/me/player/devices";
+                var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Get, url));
+                if (response == null || !response.IsSuccessStatusCode)
                 {
                     return new List<Device>();
                 }
 
-                var url = "https://api.spotify.com/v1/me/player/devices";
-                _logger.LogInformation("GET {Url}", url);
-                var request = new HttpRequestMessage(HttpMethod.Get, url);
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
+                var content = await response.Content.ReadAsStringAsync();
+                using var jsonDoc = JsonDocument.Parse(content);
+                var devices = new List<Device>();
 
-                var response = await _httpClient.SendAsync(request);
-                if (response.IsSuccessStatusCode)
+                if (jsonDoc.RootElement.TryGetProperty("devices", out var devicesArray))
                 {
-                    var content = await response.Content.ReadAsStringAsync();
-                    using var jsonDoc = JsonDocument.Parse(content);
-                    var devices = new List<Device>();
-
-                    if (jsonDoc.RootElement.TryGetProperty("devices", out var devicesArray))
+                    foreach (var deviceElement in devicesArray.EnumerateArray())
                     {
-                        foreach (var deviceElement in devicesArray.EnumerateArray())
-                        {
-                            devices.Add(new Device
-                            {
-                                Id = deviceElement.GetProperty("id").GetString() ?? string.Empty,
-                                Name = deviceElement.GetProperty("name").GetString() ?? string.Empty,
-                                Type = deviceElement.GetProperty("type").GetString() ?? string.Empty,
-                                IsActive = deviceElement.GetProperty("is_active").GetBoolean(),
-                                IsPrivateSession = deviceElement.GetProperty("is_private_session").GetBoolean(),
-                                IsRestricted = deviceElement.GetProperty("is_restricted").GetBoolean(),
-                                VolumePercent = deviceElement.TryGetProperty("volume_percent", out var vol) && !vol.ValueKind.Equals(JsonValueKind.Null) ? vol.GetInt32() : 0
-                            });
-                        }
+                        devices.Add(ParseDevice(deviceElement));
                     }
-
-                    return devices;
                 }
 
-                return new List<Device>();
+                return devices;
             }
             catch (Exception ex)
             {
@@ -247,17 +244,12 @@ namespace BeatBind.Infrastructure.Services
         {
             try
             {
-                if (!await EnsureValidTokenAsync())
+                var url = "https://api.spotify.com/v1/me/player/play";
+                var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Put, url));
+                if (response == null)
                 {
                     return false;
                 }
-
-                var url = "https://api.spotify.com/v1/me/player/play";
-                _logger.LogInformation("PUT {Url}", url);
-                var request = new HttpRequestMessage(HttpMethod.Put, url);
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
-
-                var response = await _httpClient.SendAsync(request);
 
                 // If we get a 404, it likely means no active device
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -265,32 +257,30 @@ namespace BeatBind.Infrastructure.Services
                     _logger.LogInformation("No active device found (404), checking for available devices");
                     var devices = await GetAvailableDevicesAsync();
 
-                    if (devices.Count > 0)
-                    {
-                        // Try to transfer playback to the first available device (prefer active ones)
-                        var device = devices.FirstOrDefault(d => d.IsActive) ?? devices.First();
-                        _logger.LogInformation("Attempting to transfer playback to device: {DeviceName}", device.Name);
-
-                        var transferBody = JsonSerializer.Serialize(new { device_ids = new[] { device.Id }, play = true });
-                        var transferUrl = "https://api.spotify.com/v1/me/player";
-                        var transferRequest = new HttpRequestMessage(HttpMethod.Put, transferUrl);
-                        transferRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
-                        transferRequest.Content = new StringContent(transferBody, Encoding.UTF8, "application/json");
-
-                        var transferResponse = await _httpClient.SendAsync(transferRequest);
-                        if (!transferResponse.IsSuccessStatusCode)
-                        {
-                            _logger.LogWarning("Failed to transfer playback. Status: {StatusCode}. Ensure Spotify has recently played content.", transferResponse.StatusCode);
-                            return false;
-                        }
-
-                        return true;
-                    }
-                    else
+                    if (devices.Count == 0)
                     {
                         _logger.LogWarning("No available devices found. Please open Spotify on a device.");
                         return false;
                     }
+
+                    // Try to transfer playback to the first available device (prefer active ones)
+                    var device = devices.FirstOrDefault(d => d.IsActive) ?? devices.First();
+                    _logger.LogInformation("Attempting to transfer playback to device: {DeviceName}", device.Name);
+
+                    var transferBody = JsonSerializer.Serialize(new { device_ids = new[] { device.Id }, play = true });
+                    var transferUrl = "https://api.spotify.com/v1/me/player";
+                    var transferResponse = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Put, transferUrl)
+                    {
+                        Content = new StringContent(transferBody, Encoding.UTF8, "application/json")
+                    });
+
+                    if (transferResponse == null || !transferResponse.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning("Failed to transfer playback. Status: {StatusCode}. Ensure Spotify has recently played content.", transferResponse?.StatusCode);
+                        return false;
+                    }
+
+                    return true;
                 }
 
                 return response.IsSuccessStatusCode;
@@ -337,28 +327,9 @@ namespace BeatBind.Infrastructure.Services
         /// <returns>True if the volume was successfully set; otherwise, false.</returns>
         public async Task<bool> SetVolumeAsync(int volume)
         {
-            try
-            {
-                if (!await EnsureValidTokenAsync())
-                {
-                    return false;
-                }
-
-                volume = Math.Clamp(volume, 0, 100);
-                var url = $"https://api.spotify.com/v1/me/player/volume?volume_percent={volume}";
-                _logger.LogInformation("PUT {Url}", url);
-
-                var request = new HttpRequestMessage(HttpMethod.Put, url);
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
-
-                var response = await _httpClient.SendAsync(request);
-                return response.IsSuccessStatusCode;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error setting volume");
-                return false;
-            }
+            volume = Math.Clamp(volume, 0, 100);
+            var url = $"https://api.spotify.com/v1/me/player/volume?volume_percent={volume}";
+            return await SendPlayerCommandAsync(url, HttpMethod.Put, useFullUrl: true);
         }
 
         /// <summary>
@@ -479,43 +450,23 @@ namespace BeatBind.Infrastructure.Services
         /// <returns>True if the seek operation was successful; otherwise, false.</returns>
         public async Task<bool> SeekToPositionAsync(int positionMs)
         {
-            try
-            {
-                if (!await EnsureValidTokenAsync())
-                {
-                    return false;
-                }
-
-                positionMs = Math.Max(0, positionMs);
-                var url = $"https://api.spotify.com/v1/me/player/seek?position_ms={positionMs}";
-                _logger.LogInformation("PUT {Url}", url);
-
-                var request = new HttpRequestMessage(HttpMethod.Put, url);
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
-
-                var response = await _httpClient.SendAsync(request);
-                return response.IsSuccessStatusCode;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error seeking to position");
-                return false;
-            }
+            positionMs = Math.Max(0, positionMs);
+            var url = $"https://api.spotify.com/v1/me/player/seek?position_ms={positionMs}";
+            return await SendPlayerCommandAsync(url, HttpMethod.Put, useFullUrl: true);
         }
 
         /// <summary>
         /// Ensures that a valid authentication token is available for API requests.
-        /// Authenticates or refreshes the token as needed.
+        /// Refreshes the token or reloads stored tokens as needed.
         /// </summary>
         /// <returns>True if a valid token is available; otherwise, false.</returns>
         private async Task<bool> EnsureValidTokenAsync()
         {
             if (_currentAuth == null)
             {
-                // Try to load stored authentication first before triggering new auth flow
+                // Try to load stored authentication first before giving up
                 LoadStoredAuthentication();
 
-                // If still no auth after loading, authentication is required
                 if (_currentAuth == null)
                 {
                     _logger.LogWarning("No authentication available. Please authenticate through the UI.");
@@ -523,12 +474,62 @@ namespace BeatBind.Infrastructure.Services
                 }
             }
 
-            if (!_authenticationService.IsTokenValid(_currentAuth))
+            if (_authenticationService.IsTokenValid(_currentAuth))
             {
-                return await RefreshTokenAsync();
+                return true;
             }
 
-            return true;
+            if (await RefreshTokenCoreAsync(force: false))
+            {
+                return true;
+            }
+
+            // The refresh token may have been revoked — for example the user
+            // re-authenticated through the UI, which stored new tokens this session
+            // has not seen yet. Fall back to the stored tokens before giving up.
+            LoadStoredAuthentication();
+            return _currentAuth != null && _authenticationService.IsTokenValid(_currentAuth);
+        }
+
+        /// <summary>
+        /// Sends an authorized request to the Spotify API, refreshing the token and
+        /// retrying once if the token is rejected before its expected expiry.
+        /// </summary>
+        /// <param name="createRequest">Factory that builds the request; called again for the retry.</param>
+        /// <returns>The HTTP response, or null if no valid token is available.</returns>
+        private async Task<HttpResponseMessage?> SendRequestAsync(Func<HttpRequestMessage> createRequest)
+        {
+            if (!await EnsureValidTokenAsync())
+            {
+                return null;
+            }
+
+            var response = await SendWithBearerTokenAsync(createRequest);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                // The token was rejected before its expected expiry (revoked or clock
+                // skew) — refresh and retry once
+                _logger.LogInformation("Received 401 from Spotify API, refreshing token and retrying once");
+                if (await RefreshTokenCoreAsync(force: true))
+                {
+                    response.Dispose();
+                    response = await SendWithBearerTokenAsync(createRequest);
+                }
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Builds a request via the factory, attaches the current bearer token, and sends it.
+        /// </summary>
+        private async Task<HttpResponseMessage> SendWithBearerTokenAsync(Func<HttpRequestMessage> createRequest)
+        {
+            var request = createRequest();
+            _logger.LogDebug("{Method} {Url}", request.Method.Method, request.RequestUri);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -543,23 +544,18 @@ namespace BeatBind.Infrastructure.Services
         {
             try
             {
-                if (!await EnsureValidTokenAsync())
-                {
-                    return false;
-                }
-
                 var url = useFullUrl ? endpoint : $"https://api.spotify.com/v1/me/player/{endpoint}";
-                _logger.LogInformation("{Method} {Url}", method.Method, url);
-                var request = new HttpRequestMessage(method, url);
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
-
-                if (!string.IsNullOrEmpty(body))
+                var response = await SendRequestAsync(() =>
                 {
-                    request.Content = new StringContent(body, Encoding.UTF8, "application/json");
-                }
+                    var request = new HttpRequestMessage(method, url);
+                    if (!string.IsNullOrEmpty(body))
+                    {
+                        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+                    }
+                    return request;
+                });
 
-                var response = await _httpClient.SendAsync(request);
-                return response.IsSuccessStatusCode;
+                return response != null && response.IsSuccessStatusCode;
             }
             catch (Exception ex)
             {
@@ -570,6 +566,9 @@ namespace BeatBind.Infrastructure.Services
 
         /// <summary>
         /// Parses the JSON response from Spotify API into a PlaybackState object.
+        /// Several fields ("item", "progress_ms", device "volume_percent") are
+        /// documented as nullable — e.g. during ad breaks or private sessions —
+        /// so they all fall back to defaults instead of throwing.
         /// </summary>
         /// <param name="root">The root JSON element from the API response.</param>
         /// <returns>A populated PlaybackState object.</returns>
@@ -579,13 +578,11 @@ namespace BeatBind.Infrastructure.Services
             {
                 IsPlaying = root.GetProperty("is_playing").GetBoolean(),
                 ShuffleState = root.GetProperty("shuffle_state").GetBoolean(),
-                Volume = root.GetProperty("device").GetProperty("volume_percent").GetInt32(),
-                ProgressMs = root.GetProperty("progress_ms").GetInt32()
+                ProgressMs = GetInt32OrDefault(root, "progress_ms")
             };
 
             // Parse repeat state
-            var repeatState = root.GetProperty("repeat_state").GetString();
-            playbackState.RepeatState = repeatState switch
+            playbackState.RepeatState = GetStringOrEmpty(root, "repeat_state") switch
             {
                 "off" => RepeatMode.Off,
                 "track" => RepeatMode.Track,
@@ -593,43 +590,79 @@ namespace BeatBind.Infrastructure.Services
                 _ => RepeatMode.Off
             };
 
-            // Parse current track
-            if (root.TryGetProperty("item", out var item))
+            // Parse current track ("item" is null during ad breaks and for episodes
+            // when additional_types is not requested)
+            if (root.TryGetProperty("item", out var item) && item.ValueKind == JsonValueKind.Object)
             {
-                var durationMs = item.GetProperty("duration_ms").GetInt32();
+                var durationMs = GetInt32OrDefault(item, "duration_ms");
                 playbackState.DurationMs = durationMs;
 
                 playbackState.CurrentTrack = new Track
                 {
-                    Id = item.GetProperty("id").GetString() ?? string.Empty,
-                    Name = item.GetProperty("name").GetString() ?? string.Empty,
-                    Uri = item.GetProperty("uri").GetString() ?? string.Empty,
+                    Id = GetStringOrEmpty(item, "id"),
+                    Name = GetStringOrEmpty(item, "name"),
+                    Uri = GetStringOrEmpty(item, "uri"),
                     DurationMs = durationMs,
-                    Artist = item.GetProperty("artists").GetArrayLength() > 0
-                        ? item.GetProperty("artists")[0].GetProperty("name").GetString() ?? string.Empty
+                    Artist = item.TryGetProperty("artists", out var artists) &&
+                             artists.ValueKind == JsonValueKind.Array &&
+                             artists.GetArrayLength() > 0
+                        ? GetStringOrEmpty(artists[0], "name")
                         : string.Empty,
-                    Album = item.GetProperty("album").GetProperty("name").GetString() ?? string.Empty,
+                    Album = item.TryGetProperty("album", out var album) && album.ValueKind == JsonValueKind.Object
+                        ? GetStringOrEmpty(album, "name")
+                        : string.Empty,
                     IsPlaying = playbackState.IsPlaying,
                     ProgressMs = playbackState.ProgressMs
                 };
             }
 
             // Parse device
-            if (root.TryGetProperty("device", out var device))
+            if (root.TryGetProperty("device", out var device) && device.ValueKind == JsonValueKind.Object)
             {
-                playbackState.Device = new Device
-                {
-                    Id = device.GetProperty("id").GetString() ?? string.Empty,
-                    Name = device.GetProperty("name").GetString() ?? string.Empty,
-                    Type = device.GetProperty("type").GetString() ?? string.Empty,
-                    IsActive = device.GetProperty("is_active").GetBoolean(),
-                    IsPrivateSession = device.GetProperty("is_private_session").GetBoolean(),
-                    IsRestricted = device.GetProperty("is_restricted").GetBoolean(),
-                    VolumePercent = device.GetProperty("volume_percent").GetInt32()
-                };
+                playbackState.Volume = GetInt32OrDefault(device, "volume_percent");
+                playbackState.Device = ParseDevice(device);
             }
 
             return playbackState;
+        }
+
+        /// <summary>
+        /// Parses a device JSON element into a Device object.
+        /// </summary>
+        /// <param name="device">The device JSON element.</param>
+        /// <returns>A populated Device object.</returns>
+        private static Device ParseDevice(JsonElement device)
+        {
+            return new Device
+            {
+                Id = GetStringOrEmpty(device, "id"),
+                Name = GetStringOrEmpty(device, "name"),
+                Type = GetStringOrEmpty(device, "type"),
+                IsActive = device.GetProperty("is_active").GetBoolean(),
+                IsPrivateSession = device.GetProperty("is_private_session").GetBoolean(),
+                IsRestricted = device.GetProperty("is_restricted").GetBoolean(),
+                VolumePercent = GetInt32OrDefault(device, "volume_percent")
+            };
+        }
+
+        /// <summary>
+        /// Reads an integer property that may be missing or JSON null, returning 0 in those cases.
+        /// </summary>
+        private static int GetInt32OrDefault(JsonElement parent, string propertyName)
+        {
+            return parent.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.Number
+                ? value.GetInt32()
+                : 0;
+        }
+
+        /// <summary>
+        /// Reads a string property that may be missing or JSON null, returning an empty string in those cases.
+        /// </summary>
+        private static string GetStringOrEmpty(JsonElement parent, string propertyName)
+        {
+            return parent.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString() ?? string.Empty
+                : string.Empty;
         }
     }
 }

--- a/src/BeatBind.Infrastructure/Services/SpotifyService.cs
+++ b/src/BeatBind.Infrastructure/Services/SpotifyService.cs
@@ -333,61 +333,32 @@ namespace BeatBind.Infrastructure.Services
         }
 
         /// <summary>
-        /// Toggles the shuffle mode for the current playback.
+        /// Sets the shuffle mode for the current playback.
         /// </summary>
-        /// <returns>True if shuffle mode was successfully toggled; otherwise, false.</returns>
-        public async Task<bool> ToggleShuffleAsync()
+        /// <param name="state">True to enable shuffle; false to disable it.</param>
+        /// <returns>True if shuffle mode was successfully set; otherwise, false.</returns>
+        public async Task<bool> SetShuffleAsync(bool state)
         {
-            try
-            {
-                var playback = await GetCurrentPlaybackAsync();
-                if (playback == null)
-                {
-                    return false;
-                }
-
-                var newShuffleState = !playback.ShuffleState;
-                var url = $"https://api.spotify.com/v1/me/player/shuffle?state={newShuffleState.ToString().ToLower()}";
-
-                return await SendPlayerCommandAsync(url, HttpMethod.Put, useFullUrl: true);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error toggling shuffle");
-                return false;
-            }
+            var url = $"https://api.spotify.com/v1/me/player/shuffle?state={(state ? "true" : "false")}";
+            return await SendPlayerCommandAsync(url, HttpMethod.Put, useFullUrl: true);
         }
 
         /// <summary>
-        /// Cycles through repeat modes: Off -> Context -> Track -> Off.
+        /// Sets the repeat mode for the current playback.
         /// </summary>
-        /// <returns>True if repeat mode was successfully changed; otherwise, false.</returns>
-        public async Task<bool> ToggleRepeatAsync()
+        /// <param name="mode">The repeat mode to set.</param>
+        /// <returns>True if repeat mode was successfully set; otherwise, false.</returns>
+        public async Task<bool> SetRepeatAsync(RepeatMode mode)
         {
-            try
+            var state = mode switch
             {
-                var playback = await GetCurrentPlaybackAsync();
-                if (playback == null)
-                {
-                    return false;
-                }
+                RepeatMode.Track => "track",
+                RepeatMode.Context => "context",
+                _ => "off"
+            };
 
-                var newRepeatState = playback.RepeatState switch
-                {
-                    RepeatMode.Off => "context",
-                    RepeatMode.Context => "track",
-                    RepeatMode.Track => "off",
-                    _ => "off"
-                };
-
-                var url = $"https://api.spotify.com/v1/me/player/repeat?state={newRepeatState}";
-                return await SendPlayerCommandAsync(url, HttpMethod.Put, useFullUrl: true);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error toggling repeat");
-                return false;
-            }
+            var url = $"https://api.spotify.com/v1/me/player/repeat?state={state}";
+            return await SendPlayerCommandAsync(url, HttpMethod.Put, useFullUrl: true);
         }
 
         /// <summary>
@@ -529,6 +500,12 @@ namespace BeatBind.Infrastructure.Services
             var request = createRequest();
             _logger.LogDebug("{Method} {Url}", request.Method.Method, request.RequestUri);
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
+
+            // Prefer HTTP/2 so the handler's keep-alive pings apply and the
+            // connection stays warm between hotkey presses
+            request.Version = System.Net.HttpVersion.Version20;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+
             return await _httpClient.SendAsync(request);
         }
 

--- a/src/BeatBind.Infrastructure/Services/SpotifyService.cs
+++ b/src/BeatBind.Infrastructure/Services/SpotifyService.cs
@@ -33,6 +33,11 @@ namespace BeatBind.Infrastructure.Services
             _logger = logger;
             _authenticationService = authenticationService;
 
+            // Adopt tokens saved by any auth path (UI re-auth, refresh) immediately,
+            // so a switch to a different Spotify account takes effect on the next
+            // hotkey press instead of after the old token expires
+            _authenticationService.AuthenticationSaved += (_, authResult) => _currentAuth = authResult;
+
             // Try to load stored authentication on startup
             LoadStoredAuthentication();
 
@@ -172,7 +177,7 @@ namespace BeatBind.Infrastructure.Services
             try
             {
                 var url = "https://api.spotify.com/v1/me/player";
-                var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Get, url));
+                using var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Get, url));
                 if (response == null)
                 {
                     return null;
@@ -208,7 +213,7 @@ namespace BeatBind.Infrastructure.Services
             try
             {
                 var url = "https://api.spotify.com/v1/me/player/devices";
-                var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Get, url));
+                using var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Get, url));
                 if (response == null || !response.IsSuccessStatusCode)
                 {
                     return new List<Device>();
@@ -245,7 +250,7 @@ namespace BeatBind.Infrastructure.Services
             try
             {
                 var url = "https://api.spotify.com/v1/me/player/play";
-                var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Put, url));
+                using var response = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Put, url));
                 if (response == null)
                 {
                     return false;
@@ -269,7 +274,7 @@ namespace BeatBind.Infrastructure.Services
 
                     var transferBody = JsonSerializer.Serialize(new { device_ids = new[] { device.Id }, play = true });
                     var transferUrl = "https://api.spotify.com/v1/me/player";
-                    var transferResponse = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Put, transferUrl)
+                    using var transferResponse = await SendRequestAsync(() => new HttpRequestMessage(HttpMethod.Put, transferUrl)
                     {
                         Content = new StringContent(transferBody, Encoding.UTF8, "application/json")
                     });
@@ -498,7 +503,9 @@ namespace BeatBind.Infrastructure.Services
         private async Task<HttpResponseMessage> SendWithBearerTokenAsync(Func<HttpRequestMessage> createRequest)
         {
             var request = createRequest();
-            _logger.LogDebug("{Method} {Url}", request.Method.Method, request.RequestUri);
+            // Information level on purpose: the rolling log file is the only
+            // artifact for diagnosing "my hotkey did nothing" reports
+            _logger.LogInformation("{Method} {Url}", request.Method.Method, request.RequestUri);
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _currentAuth!.AccessToken);
 
             // Prefer HTTP/2 so the handler's keep-alive pings apply and the
@@ -522,7 +529,7 @@ namespace BeatBind.Infrastructure.Services
             try
             {
                 var url = useFullUrl ? endpoint : $"https://api.spotify.com/v1/me/player/{endpoint}";
-                var response = await SendRequestAsync(() =>
+                using var response = await SendRequestAsync(() =>
                 {
                     var request = new HttpRequestMessage(method, url);
                     if (!string.IsNullOrEmpty(body))
@@ -593,10 +600,12 @@ namespace BeatBind.Infrastructure.Services
                 };
             }
 
-            // Parse device
+            // Parse device. Volume stays null when volume_percent is JSON null
+            // (ad breaks, casting/restricted devices) so volume and mute commands
+            // know the real level is unknown instead of treating it as 0
             if (root.TryGetProperty("device", out var device) && device.ValueKind == JsonValueKind.Object)
             {
-                playbackState.Volume = GetInt32OrDefault(device, "volume_percent");
+                playbackState.Volume = GetInt32OrNull(device, "volume_percent");
                 playbackState.Device = ParseDevice(device);
             }
 
@@ -630,6 +639,16 @@ namespace BeatBind.Infrastructure.Services
             return parent.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.Number
                 ? value.GetInt32()
                 : 0;
+        }
+
+        /// <summary>
+        /// Reads an integer property that may be missing or JSON null, returning null in those cases.
+        /// </summary>
+        private static int? GetInt32OrNull(JsonElement parent, string propertyName)
+        {
+            return parent.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.Number
+                ? value.GetInt32()
+                : null;
         }
 
         /// <summary>

--- a/src/BeatBind.Presentation/Components/HotkeyEditorDialog.cs
+++ b/src/BeatBind.Presentation/Components/HotkeyEditorDialog.cs
@@ -427,12 +427,7 @@ namespace BeatBind.Presentation.Components
         {
             if (ValidateInput())
             {
-                // If this is a new hotkey (ID is 0), generate a new ID
-                if (Hotkey.Id == 0)
-                {
-                    Hotkey.Id = Environment.TickCount;
-                }
-
+                // New hotkeys keep Id 0 here; HotkeysPanel assigns the next free ID
                 Hotkey.Action = _actionComboBox.SelectedValue is HotkeyAction action
                     ? action
                     : HotkeyAction.PlayPause; // or another default/fallback action

--- a/src/BeatBind.Presentation/MainForm.cs
+++ b/src/BeatBind.Presentation/MainForm.cs
@@ -24,6 +24,7 @@ namespace BeatBind.Presentation
         private readonly IGithubReleaseService _githubReleaseService;
         private readonly IStartupService _startupService;
         private readonly ILogger<MainForm> _logger;
+        private readonly ILoggerFactory _loggerFactory;
 
         private NotifyIcon? _notifyIcon;
         private Panel? _updateNotificationPanel;
@@ -50,6 +51,7 @@ namespace BeatBind.Presentation
             _githubReleaseService = null!;
             _startupService = null!;
             _logger = NullLogger<MainForm>.Instance;
+            _loggerFactory = NullLoggerFactory.Instance;
 
             if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
             {
@@ -69,18 +71,21 @@ namespace BeatBind.Presentation
         /// <param name="githubReleaseService">Service for checking GitHub releases</param>
         /// <param name="startupService">Service for startup management</param>
         /// <param name="logger">Logger instance</param>
+        /// <param name="loggerFactory">Factory used to create loggers for the child panels</param>
         public MainForm(
             AuthenticationApplicationService authenticationService,
             IConfigurationService configurationService,
             IGithubReleaseService githubReleaseService,
             IStartupService startupService,
-            ILogger<MainForm> logger)
+            ILogger<MainForm> logger,
+            ILoggerFactory loggerFactory)
         {
             _authenticationService = authenticationService;
             _configurationService = configurationService;
             _githubReleaseService = githubReleaseService;
             _startupService = startupService;
             _logger = logger;
+            _loggerFactory = loggerFactory;
 
             // Initialize MaterialSkinManager
             _materialSkinManager = MaterialSkinManager.Instance;
@@ -199,9 +204,9 @@ namespace BeatBind.Presentation
             };
 
             // Create panels
-            _authenticationPanel = new AuthenticationPanel(_authenticationService, _configurationService, NullLogger<AuthenticationPanel>.Instance);
-            _hotkeysPanel = new HotkeysPanel(NullLogger<HotkeysPanel>.Instance);
-            _settingsPanel = new SettingsPanel(_configurationService, _startupService, NullLogger<SettingsPanel>.Instance);
+            _authenticationPanel = new AuthenticationPanel(_authenticationService, _configurationService, _loggerFactory.CreateLogger<AuthenticationPanel>());
+            _hotkeysPanel = new HotkeysPanel(_loggerFactory.CreateLogger<HotkeysPanel>());
+            _settingsPanel = new SettingsPanel(_configurationService, _startupService, _loggerFactory.CreateLogger<SettingsPanel>());
 
             // Wire up panel events
             _hotkeysPanel.HotkeyEditRequested += HotkeysPanel_HotkeyEditRequested;

--- a/src/BeatBind.Presentation/MainForm.cs
+++ b/src/BeatBind.Presentation/MainForm.cs
@@ -15,7 +15,10 @@ namespace BeatBind.Presentation
 {
     public partial class MainForm : MaterialForm
     {
-        public const string CURRENT_VERSION = "2.0.4";
+        // Single source of truth for the app version (compared against GitHub
+        // releases by the update checker). When bumping, also update the version
+        // badge in README.md — see CONTRIBUTING.md "Releasing a new version".
+        public const string CURRENT_VERSION = "2.1.0";
 
         private readonly MaterialSkinManager _materialSkinManager;
         private readonly AuthenticationApplicationService _authenticationService;

--- a/src/BeatBind.Presentation/Panels/HotkeysPanel.cs
+++ b/src/BeatBind.Presentation/Panels/HotkeysPanel.cs
@@ -152,6 +152,13 @@ public partial class HotkeysPanel : BasePanelControl
         {
             var hotkey = hotkeyDialog.Hotkey;
 
+            // Assign the next free ID; the ID keys the UI entry dictionary and the
+            // hotkey registration, so duplicates would silently drop hotkeys
+            if (hotkey.Id == 0)
+            {
+                hotkey.Id = GetHotkeysFromUI().Select(h => h.Id).DefaultIfEmpty(0).Max() + 1;
+            }
+
             var existingHotkey = GetHotkeysFromUI().FirstOrDefault(h => h.Action == hotkey.Action);
             if (existingHotkey != null)
             {

--- a/src/BeatBind.Tests/Application/Services/MusicControlApplicationServiceTests.cs
+++ b/src/BeatBind.Tests/Application/Services/MusicControlApplicationServiceTests.cs
@@ -419,17 +419,77 @@ namespace BeatBind.Tests.Application.Services
         }
 
         [Fact]
-        public async Task ToggleShuffleAsync_ShouldCallSpotifyService()
+        public async Task ToggleShuffleAsync_WhenShuffleOff_ShouldEnableShuffle()
         {
             // Arrange
-            _mockSpotifyService.Setup(x => x.ToggleShuffleAsync()).ReturnsAsync(true);
+            var playbackState = new PlaybackState
+            {
+                IsPlaying = true,
+                Volume = 50,
+                ShuffleState = false,
+                ProgressMs = 1000,
+                DurationMs = 200000
+            };
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+            _mockSpotifyService.Setup(x => x.SetShuffleAsync(true)).ReturnsAsync(true);
 
             // Act
             var result = await _service.ToggleShuffleAsync();
 
             // Assert
             result.Should().BeTrue();
-            _mockSpotifyService.Verify(x => x.ToggleShuffleAsync(), Times.Once);
+            _mockSpotifyService.Verify(x => x.SetShuffleAsync(true), Times.Once);
+        }
+
+        [Fact]
+        public async Task ToggleShuffleAsync_WhenPressedTwiceRapidly_ShouldToggleBothWays()
+        {
+            // Arrange — the second press within the cache window must see the shuffle
+            // state left by the first press
+            var playbackState = new PlaybackState
+            {
+                IsPlaying = true,
+                Volume = 50,
+                ShuffleState = false,
+                ProgressMs = 1000,
+                DurationMs = 200000
+            };
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+            _mockSpotifyService.Setup(x => x.SetShuffleAsync(It.IsAny<bool>())).ReturnsAsync(true);
+
+            // Act
+            var first = await _service.ToggleShuffleAsync();
+            var second = await _service.ToggleShuffleAsync();
+
+            // Assert
+            first.Should().BeTrue();
+            second.Should().BeTrue();
+            _mockSpotifyService.Verify(x => x.GetCurrentPlaybackAsync(), Times.Once);
+            _mockSpotifyService.Verify(x => x.SetShuffleAsync(true), Times.Once);
+            _mockSpotifyService.Verify(x => x.SetShuffleAsync(false), Times.Once);
+        }
+
+        [Fact]
+        public async Task ToggleRepeatAsync_WhenRepeatOff_ShouldSetToContext()
+        {
+            // Arrange
+            var playbackState = new PlaybackState
+            {
+                IsPlaying = true,
+                Volume = 50,
+                RepeatState = RepeatMode.Off,
+                ProgressMs = 1000,
+                DurationMs = 200000
+            };
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+            _mockSpotifyService.Setup(x => x.SetRepeatAsync(RepeatMode.Context)).ReturnsAsync(true);
+
+            // Act
+            var result = await _service.ToggleRepeatAsync();
+
+            // Assert
+            result.Should().BeTrue();
+            _mockSpotifyService.Verify(x => x.SetRepeatAsync(RepeatMode.Context), Times.Once);
         }
 
         [Fact]
@@ -577,7 +637,7 @@ namespace BeatBind.Tests.Application.Services
         public async Task ToggleShuffleAsync_WhenExceptionThrown_ShouldReturnFalse()
         {
             // Arrange
-            _mockSpotifyService.Setup(x => x.ToggleShuffleAsync()).ThrowsAsync(new Exception("API error"));
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ThrowsAsync(new Exception("API error"));
 
             // Act
             var result = await _service.ToggleShuffleAsync();
@@ -590,7 +650,7 @@ namespace BeatBind.Tests.Application.Services
         public async Task ToggleRepeatAsync_WhenExceptionThrown_ShouldReturnFalse()
         {
             // Arrange
-            _mockSpotifyService.Setup(x => x.ToggleRepeatAsync()).ThrowsAsync(new Exception("API error"));
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ThrowsAsync(new Exception("API error"));
 
             // Act
             var result = await _service.ToggleRepeatAsync();

--- a/src/BeatBind.Tests/Application/Services/MusicControlApplicationServiceTests.cs
+++ b/src/BeatBind.Tests/Application/Services/MusicControlApplicationServiceTests.cs
@@ -748,6 +748,70 @@ namespace BeatBind.Tests.Application.Services
         }
 
         [Fact]
+        public async Task VolumeUpAsync_WhenPressedRapidly_ShouldReuseCachedPlaybackState()
+        {
+            // Arrange — presses within the cache window should fetch the playback
+            // state once and compute successive volume steps locally
+            var config = new ApplicationConfiguration { VolumeSteps = 10 };
+            var playbackState = new PlaybackState { IsPlaying = true, Volume = 50, ProgressMs = 1000, DurationMs = 200000 };
+            _mockConfigService.Setup(x => x.GetConfiguration()).Returns(config);
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+            _mockSpotifyService.Setup(x => x.SetVolumeAsync(It.IsAny<int>())).ReturnsAsync(true);
+
+            // Act
+            var first = await _service.VolumeUpAsync();
+            var second = await _service.VolumeUpAsync();
+
+            // Assert
+            first.Should().BeTrue();
+            second.Should().BeTrue();
+            _mockSpotifyService.Verify(x => x.GetCurrentPlaybackAsync(), Times.Once);
+            _mockSpotifyService.Verify(x => x.SetVolumeAsync(60), Times.Once);
+            _mockSpotifyService.Verify(x => x.SetVolumeAsync(70), Times.Once);
+        }
+
+        [Fact]
+        public async Task NextTrackAsync_ShouldInvalidateCachedPlaybackState()
+        {
+            // Arrange
+            var config = new ApplicationConfiguration { VolumeSteps = 10 };
+            _mockConfigService.Setup(x => x.GetConfiguration()).Returns(config);
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync())
+                .ReturnsAsync(() => new PlaybackState { IsPlaying = true, Volume = 50, ProgressMs = 1000, DurationMs = 200000 });
+            _mockSpotifyService.Setup(x => x.SetVolumeAsync(It.IsAny<int>())).ReturnsAsync(true);
+            _mockSpotifyService.Setup(x => x.NextTrackAsync()).ReturnsAsync(true);
+
+            // Act — the skip changes the track, so the cached state must be discarded
+            await _service.VolumeUpAsync();
+            await _service.NextTrackAsync();
+            await _service.VolumeUpAsync();
+
+            // Assert
+            _mockSpotifyService.Verify(x => x.GetCurrentPlaybackAsync(), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task PlayPauseAsync_WhenPressedTwiceRapidly_ShouldToggleBothWays()
+        {
+            // Arrange — the second press within the cache window must see the state
+            // left by the first press, not the original snapshot
+            var playbackState = new PlaybackState { IsPlaying = true, Volume = 50, ProgressMs = 1000, DurationMs = 200000 };
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+            _mockSpotifyService.Setup(x => x.PauseAsync()).ReturnsAsync(true);
+            _mockSpotifyService.Setup(x => x.PlayAsync()).ReturnsAsync(true);
+
+            // Act
+            var first = await _service.PlayPauseAsync();
+            var second = await _service.PlayPauseAsync();
+
+            // Assert
+            first.Should().BeTrue();
+            second.Should().BeTrue();
+            _mockSpotifyService.Verify(x => x.PauseAsync(), Times.Once);
+            _mockSpotifyService.Verify(x => x.PlayAsync(), Times.Once);
+        }
+
+        [Fact]
         public async Task PreviousTrackAsync_WhenRewindToStartAndNoPlaybackState_ShouldGoToPreviousTrack()
         {
             // Arrange

--- a/src/BeatBind.Tests/Application/Services/MusicControlApplicationServiceTests.cs
+++ b/src/BeatBind.Tests/Application/Services/MusicControlApplicationServiceTests.cs
@@ -808,6 +808,61 @@ namespace BeatBind.Tests.Application.Services
         }
 
         [Fact]
+        public async Task VolumeUpAsync_WhenDeviceVolumeUnknown_ShouldDoNothing()
+        {
+            // Arrange — Spotify reports volume_percent: null for some devices and
+            // during ads; stepping from an assumed level would yank the real volume
+            var config = new ApplicationConfiguration { VolumeSteps = 10 };
+            var playbackState = new PlaybackState { IsPlaying = true, Volume = null, ProgressMs = 1000, DurationMs = 200000 };
+            _mockConfigService.Setup(x => x.GetConfiguration()).Returns(config);
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+
+            // Act
+            var result = await _service.VolumeUpAsync();
+
+            // Assert
+            result.Should().BeFalse();
+            _mockSpotifyService.Verify(x => x.SetVolumeAsync(It.IsAny<int>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ToggleMuteAsync_WhenDeviceVolumeUnknown_ShouldDoNothing()
+        {
+            // Arrange — an unknown volume must not be treated as muted
+            var playbackState = new PlaybackState { IsPlaying = true, Volume = null, ProgressMs = 1000, DurationMs = 200000 };
+            _mockSpotifyService.Setup(x => x.GetCurrentPlaybackAsync()).ReturnsAsync(playbackState);
+
+            // Act
+            var result = await _service.ToggleMuteAsync();
+
+            // Assert
+            result.Should().BeFalse();
+            _mockSpotifyService.Verify(x => x.SetVolumeAsync(It.IsAny<int>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task PlayPauseAsync_WhenCachedStateIsStale_ShouldRefetchAndRetry()
+        {
+            // Arrange — the cached state says playing, but playback ended on its
+            // own, so the pause is rejected; the service must refetch and retry
+            var staleState = new PlaybackState { IsPlaying = true, Volume = 50, ProgressMs = 1000, DurationMs = 200000 };
+            var freshState = new PlaybackState { IsPlaying = false, Volume = 50, ProgressMs = 0, DurationMs = 200000 };
+            _mockSpotifyService.SetupSequence(x => x.GetCurrentPlaybackAsync())
+                .ReturnsAsync(staleState)
+                .ReturnsAsync(freshState);
+            _mockSpotifyService.Setup(x => x.PauseAsync()).ReturnsAsync(false);
+            _mockSpotifyService.Setup(x => x.PlayAsync()).ReturnsAsync(true);
+
+            // Act
+            var result = await _service.PlayPauseAsync();
+
+            // Assert
+            result.Should().BeTrue();
+            _mockSpotifyService.Verify(x => x.PauseAsync(), Times.Once);
+            _mockSpotifyService.Verify(x => x.PlayAsync(), Times.Once);
+        }
+
+        [Fact]
         public async Task VolumeUpAsync_WhenPressedRapidly_ShouldReuseCachedPlaybackState()
         {
             // Arrange — presses within the cache window should fetch the playback

--- a/src/BeatBind.Tests/Core/Entities/PlaybackStateTests.cs
+++ b/src/BeatBind.Tests/Core/Entities/PlaybackStateTests.cs
@@ -13,7 +13,7 @@ namespace BeatBind.Tests.Core.Entities
 
             // Assert
             playbackState.IsPlaying.Should().BeFalse();
-            playbackState.Volume.Should().Be(0);
+            playbackState.Volume.Should().BeNull(); // null = device volume unknown
             playbackState.ProgressMs.Should().Be(0);
             playbackState.DurationMs.Should().Be(0);
             playbackState.ShuffleState.Should().BeFalse();

--- a/src/BeatBind.Tests/Infrastructure/Services/AuthenticationServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/AuthenticationServiceTests.cs
@@ -409,6 +409,31 @@ namespace BeatBind.Tests.Infrastructure.Services
         }
 
         [Fact]
+        public void SaveAuthentication_ShouldRaiseAuthenticationSaved()
+        {
+            // Arrange — long-lived consumers rely on this event to adopt new tokens
+            var config = new ApplicationConfiguration();
+            _mockConfigService.Setup(x => x.GetConfiguration()).Returns(config);
+
+            AuthenticationResult? raised = null;
+            _service.AuthenticationSaved += (_, auth) => raised = auth;
+
+            var authResult = new AuthenticationResult
+            {
+                Success = true,
+                AccessToken = "test-token",
+                RefreshToken = "test-refresh",
+                ExpiresAt = DateTime.UtcNow.AddHours(1)
+            };
+
+            // Act
+            _service.SaveAuthentication(authResult);
+
+            // Assert
+            raised.Should().BeSameAs(authResult);
+        }
+
+        [Fact]
         public void IsTokenValid_WithTokenExpiringWithinSafetyMargin_ShouldReturnFalse()
         {
             // Arrange — a token expiring in 30 seconds is inside the 60-second safety

--- a/src/BeatBind.Tests/Infrastructure/Services/AuthenticationServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/AuthenticationServiceTests.cs
@@ -408,6 +408,25 @@ namespace BeatBind.Tests.Infrastructure.Services
             result.Should().BeFalse();
         }
 
+        [Fact]
+        public void IsTokenValid_WithTokenExpiringWithinSafetyMargin_ShouldReturnFalse()
+        {
+            // Arrange — a token expiring in 30 seconds is inside the 60-second safety
+            // margin and should be treated as expired so it is refreshed proactively
+            var authResult = new AuthenticationResult
+            {
+                Success = true,
+                AccessToken = "token",
+                ExpiresAt = DateTime.UtcNow.AddSeconds(30)
+            };
+
+            // Act
+            var result = _service.IsTokenValid(authResult);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
         private void SetupHttpResponse(HttpStatusCode statusCode, string content)
         {
             _mockHttpMessageHandler.Protected()

--- a/src/BeatBind.Tests/Infrastructure/Services/HotkeyServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/HotkeyServiceTests.cs
@@ -178,6 +178,97 @@ namespace BeatBind.Tests.Infrastructure.Services
                 Times.Once);
         }
 
+        // Virtual key codes used by the key-simulation tests
+        private const int VkLWin = 0x5B;
+        private const int VkLMenu = 0xA4; // left Alt
+        private const int VkNumPad3 = 0x63;
+
+        // Regression test for the Win+L lock bug: the Win key-down is seen by the
+        // hook, but its key-up happens on the secure desktop where low-level hooks
+        // receive no events. Without pruning, the phantom Win modifier blocks all
+        // hotkey matching until the app is restarted.
+        [Fact]
+        public void Hotkey_AfterKeyUpLostToSecureDesktop_ShouldStillTrigger()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggered = new ManualResetEventSlim(false);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => triggered.Set());
+
+            // Win+L: key-down observed, key-up swallowed by the lock screen
+            service.SimulateKeyDown(VkLWin);
+            service.SimulateLostKeyUp(VkLWin);
+
+            // After unlock, the user presses Alt+NumPad3
+            service.SimulateKeyDown(VkLMenu);
+            var suppressed = service.SimulateKeyDown(VkNumPad3);
+
+            suppressed.Should().BeTrue("the phantom Win key should be pruned so the hotkey matches");
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Hotkey_WithHeldModifier_ShouldNotBePrunedAndShouldTrigger()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggered = new ManualResetEventSlim(false);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => triggered.Set());
+
+            // Normal use: Alt is genuinely held when the main key goes down
+            service.SimulateKeyDown(VkLMenu);
+            var suppressed = service.SimulateKeyDown(VkNumPad3);
+
+            suppressed.Should().BeTrue();
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        }
+
+        // A key-down this hook suppresses never reaches the OS input state, so
+        // GetAsyncKeyState reports it as up while it is physically held. The key
+        // currently being processed must therefore be excluded from pruning.
+        [Fact]
+        public void Hotkey_WhoseKeyDownIsNotReflectedInOsState_ShouldStillTrigger()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggered = new ManualResetEventSlim(false);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => triggered.Set());
+
+            service.SimulateKeyDown(VkLMenu);
+            var suppressed = service.SimulateKeyDownInvisibleToOS(VkNumPad3);
+
+            suppressed.Should().BeTrue("the current key must not be pruned even if the OS state does not show it down");
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Hotkey_AfterMainKeyUpLostToSecureDesktop_ShouldTriggerOnNextPress()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggerCount = 0;
+            var triggered = new SemaphoreSlim(0);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => { Interlocked.Increment(ref triggerCount); triggered.Release(); });
+
+            // Hotkey fires, then both key-ups are lost (e.g. locked mid-press)
+            service.SimulateKeyDown(VkLMenu);
+            service.SimulateKeyDown(VkNumPad3);
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            service.SimulateLostKeyUp(VkNumPad3);
+            service.SimulateLostKeyUp(VkLMenu);
+
+            // After unlock the same hotkey is pressed again
+            service.SimulateKeyDown(VkLMenu);
+            service.SimulateKeyDown(VkNumPad3);
+
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            triggerCount.Should().Be(2);
+        }
+
         // Testable subclass to bypass P/Invoke
         private class TestableHotkeyService : HotkeyService
         {
@@ -208,6 +299,40 @@ namespace BeatBind.Tests.Infrastructure.Services
                 IsHookInstalled = false;
                 UninstallCallCount++;
             }
+        }
+
+        // Simulates key events and OS key state without P/Invoke. "Lost" key-ups
+        // update the simulated OS state but never reach the hook — exactly what
+        // happens when Windows switches to the secure desktop (Win+L, UAC).
+        private class KeySimulatingHotkeyService : HotkeyService
+        {
+            private readonly HashSet<int> _osKeysDown = new();
+
+            public KeySimulatingHotkeyService(ILogger<HotkeyService> logger) : base(logger) { }
+
+            public bool SimulateKeyDown(int vkCode)
+            {
+                _osKeysDown.Add(vkCode);
+                return ProcessKeyDown(vkCode);
+            }
+
+            // A key-down whose event was suppressed never registers in the OS input state
+            public bool SimulateKeyDownInvisibleToOS(int vkCode)
+            {
+                return ProcessKeyDown(vkCode);
+            }
+
+            // The key is physically released but the hook never sees the key-up event
+            public void SimulateLostKeyUp(int vkCode)
+            {
+                _osKeysDown.Remove(vkCode);
+            }
+
+            protected override bool IsKeyDownInOS(int vkCode) => _osKeysDown.Contains(vkCode);
+
+            protected override IntPtr InstallHook(LowLevelKeyboardProc proc) => new IntPtr(123);
+
+            protected override void UninstallHook(IntPtr hookId) { }
         }
 
         // Always fails to install the hook — used to test error logging in the constructor

--- a/src/BeatBind.Tests/Infrastructure/Services/SpotifyServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/SpotifyServiceTests.cs
@@ -682,6 +682,103 @@ namespace BeatBind.Tests.Infrastructure.Services
             result.Should().BeFalse();
         }
 
+        [Fact]
+        public async Task GetCurrentPlaybackAsync_WithNullItemDuringAd_ShouldReturnStateWithoutTrack()
+        {
+            // Arrange — "item", "progress_ms", and "volume_percent" are documented as
+            // nullable (e.g. during ad breaks or private sessions)
+            await SetupAuthenticatedService();
+            var json = """
+            {
+                "is_playing": true,
+                "device": {
+                    "id": "device1",
+                    "name": "Test Device",
+                    "type": "Computer",
+                    "is_active": true,
+                    "is_private_session": false,
+                    "is_restricted": false,
+                    "volume_percent": null
+                },
+                "shuffle_state": false,
+                "repeat_state": "off",
+                "progress_ms": null,
+                "item": null
+            }
+            """;
+            SetupHttpResponse(HttpStatusCode.OK, json);
+
+            // Act
+            var result = await _service.GetCurrentPlaybackAsync();
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.IsPlaying.Should().BeTrue();
+            result.CurrentTrack.Should().BeNull();
+            result.ProgressMs.Should().Be(0);
+            result.Volume.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task PlayAsync_WhenTokenRejected_ShouldRefreshAndRetryOnce()
+        {
+            // Arrange — a 401 before the token's expected expiry (revoked token,
+            // clock skew) should trigger one forced refresh and one retry
+            await SetupAuthenticatedService();
+            _mockAuthService.Setup(x => x.RefreshTokenAsync(It.IsAny<string>())).ReturnsAsync(new AuthenticationResult
+            {
+                Success = true,
+                AccessToken = "new-token",
+                RefreshToken = "refresh-token",
+                ExpiresAt = DateTime.UtcNow.AddHours(1)
+            });
+
+            var sequence = _mockHttpMessageHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+            sequence.ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized });
+            sequence.ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent });
+
+            // Act
+            var result = await _service.PlayAsync();
+
+            // Assert
+            result.Should().BeTrue();
+            _mockAuthService.Verify(x => x.RefreshTokenAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task RefreshTokenAsync_WhenRefreshFails_ShouldKeepCurrentTokens()
+        {
+            // Arrange — a transient refresh failure must not wipe the refresh token,
+            // otherwise the session is broken until restart
+            await SetupAuthenticatedService();
+            _mockAuthService.Setup(x => x.RefreshTokenAsync(It.IsAny<string>())).ReturnsAsync(new AuthenticationResult
+            {
+                Success = false,
+                Error = "Service unavailable"
+            });
+
+            // Act
+            var firstAttempt = await _service.RefreshTokenAsync();
+
+            // A later attempt should still be able to use the original refresh token
+            _mockAuthService.Setup(x => x.RefreshTokenAsync("refresh-token")).ReturnsAsync(new AuthenticationResult
+            {
+                Success = true,
+                AccessToken = "new-token",
+                RefreshToken = "new-refresh-token",
+                ExpiresAt = DateTime.UtcNow.AddHours(1)
+            });
+            var secondAttempt = await _service.RefreshTokenAsync();
+
+            // Assert
+            firstAttempt.Should().BeFalse();
+            secondAttempt.Should().BeTrue();
+        }
+
         private async Task SetupAuthenticatedService()
         {
             var authResult = new AuthenticationResult

--- a/src/BeatBind.Tests/Infrastructure/Services/SpotifyServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/SpotifyServiceTests.cs
@@ -686,7 +686,38 @@ namespace BeatBind.Tests.Infrastructure.Services
             result!.IsPlaying.Should().BeTrue();
             result.CurrentTrack.Should().BeNull();
             result.ProgressMs.Should().Be(0);
-            result.Volume.Should().Be(0);
+            result.Volume.Should().BeNull(); // unknown volume must not be treated as 0
+        }
+
+        [Fact]
+        public async Task Commands_AfterAuthenticationSavedEvent_ShouldUseNewToken()
+        {
+            // Arrange — a UI re-auth (possibly to a different account) saves new
+            // tokens; the singleton service must adopt them immediately
+            await SetupAuthenticatedService();
+            SetupHttpResponse(HttpStatusCode.NoContent);
+
+            var newAuth = new AuthenticationResult
+            {
+                Success = true,
+                AccessToken = "account-b-token",
+                RefreshToken = "account-b-refresh",
+                ExpiresAt = DateTime.UtcNow.AddHours(1)
+            };
+            _mockAuthService.Raise(x => x.AuthenticationSaved += null, _mockAuthService.Object, newAuth);
+
+            // Act
+            var result = await _service.PauseAsync();
+
+            // Assert
+            result.Should().BeTrue();
+            _mockHttpMessageHandler.Protected().Verify(
+                "SendAsync",
+                Times.AtLeastOnce(),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Headers.Authorization != null &&
+                    req.Headers.Authorization.Parameter == "account-b-token"),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]

--- a/src/BeatBind.Tests/Infrastructure/Services/SpotifyServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/SpotifyServiceTests.cs
@@ -174,20 +174,25 @@ namespace BeatBind.Tests.Infrastructure.Services
         }
 
         [Fact]
-        public async Task ToggleShuffleAsync_WhenAuthenticated_ShouldCallGetPlayback()
+        public async Task SetShuffleAsync_WhenAuthenticated_ShouldSendShuffleState()
         {
             // Arrange
             await SetupAuthenticatedService();
-            SetupPlaybackResponse(shuffleState: false);
+            SetupHttpResponse(HttpStatusCode.NoContent);
 
             // Act
-            var result = await _service.ToggleShuffleAsync();
+            var result = await _service.SetShuffleAsync(true);
 
-            // Assert - Verify it attempts to get playback state
+            // Assert
+            result.Should().BeTrue();
             _mockHttpMessageHandler.Protected().Verify(
                 "SendAsync",
                 Times.AtLeastOnce(),
-                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Method == HttpMethod.Put &&
+                    req.RequestUri != null &&
+                    req.RequestUri.ToString().Contains("/me/player/shuffle") &&
+                    req.RequestUri.ToString().Contains("state=true")),
                 ItExpr.IsAny<CancellationToken>());
         }
 
@@ -436,46 +441,17 @@ namespace BeatBind.Tests.Infrastructure.Services
         }
 
         [Fact]
-        public async Task ToggleShuffleAsync_WhenPlaybackAvailable_ShouldToggle()
+        public async Task SetShuffleAsync_WhenNotAuthenticated_ShouldReturnFalse()
         {
-            // Arrange
-            await SetupAuthenticatedService();
-            var sequence = _mockHttpMessageHandler.Protected()
-                .SetupSequence<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>());
-
-            sequence.ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(GetPlaybackJson(true, false))
-            });
-            sequence.ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent });
-
             // Act
-            var result = await _service.ToggleShuffleAsync();
-
-            // Assert
-            result.Should().BeTrue();
-        }
-
-        [Fact]
-        public async Task ToggleShuffleAsync_WhenNoPlayback_ShouldReturnFalse()
-        {
-            // Arrange
-            await SetupAuthenticatedService();
-            SetupHttpResponse(HttpStatusCode.NoContent);
-
-            // Act
-            var result = await _service.ToggleShuffleAsync();
+            var result = await _service.SetShuffleAsync(true);
 
             // Assert
             result.Should().BeFalse();
         }
 
         [Fact]
-        public async Task ToggleShuffleAsync_WhenExceptionThrown_ShouldReturnFalse()
+        public async Task SetShuffleAsync_WhenExceptionThrown_ShouldReturnFalse()
         {
             // Arrange
             await SetupAuthenticatedService();
@@ -487,46 +463,40 @@ namespace BeatBind.Tests.Infrastructure.Services
                 .ThrowsAsync(new HttpRequestException("Network error"));
 
             // Act
-            var result = await _service.ToggleShuffleAsync();
+            var result = await _service.SetShuffleAsync(true);
 
             // Assert
             result.Should().BeFalse();
         }
 
         [Fact]
-        public async Task ToggleRepeatAsync_WhenRepeatOff_ShouldSetToContext()
-        {
-            // Arrange
-            await SetupAuthenticatedService();
-            var sequence = _mockHttpMessageHandler.Protected()
-                .SetupSequence<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>());
-
-            sequence.ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(GetPlaybackJson(true, false, "off"))
-            });
-            sequence.ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent });
-
-            // Act
-            var result = await _service.ToggleRepeatAsync();
-
-            // Assert
-            result.Should().BeTrue();
-        }
-
-        [Fact]
-        public async Task ToggleRepeatAsync_WhenNoPlayback_ShouldReturnFalse()
+        public async Task SetRepeatAsync_WhenAuthenticated_ShouldSendRepeatState()
         {
             // Arrange
             await SetupAuthenticatedService();
             SetupHttpResponse(HttpStatusCode.NoContent);
 
             // Act
-            var result = await _service.ToggleRepeatAsync();
+            var result = await _service.SetRepeatAsync(RepeatMode.Context);
+
+            // Assert
+            result.Should().BeTrue();
+            _mockHttpMessageHandler.Protected().Verify(
+                "SendAsync",
+                Times.AtLeastOnce(),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Method == HttpMethod.Put &&
+                    req.RequestUri != null &&
+                    req.RequestUri.ToString().Contains("/me/player/repeat") &&
+                    req.RequestUri.ToString().Contains("state=context")),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task SetRepeatAsync_WhenNotAuthenticated_ShouldReturnFalse()
+        {
+            // Act
+            var result = await _service.SetRepeatAsync(RepeatMode.Off);
 
             // Assert
             result.Should().BeFalse();

--- a/src/BeatBind/Program.cs
+++ b/src/BeatBind/Program.cs
@@ -139,11 +139,35 @@ namespace BeatBind
         private static void ConfigureInfrastructure(IServiceCollection services)
         {
             services.AddSingleton<IConfigurationService, ConfigurationService>();
-            services.AddHttpClient<ISpotifyService, SpotifyService>();
-            services.AddHttpClient<IAuthenticationService, AuthenticationService>();
+
+            // SpotifyService and AuthenticationService carry authentication state, so
+            // they must be singletons — transient copies (the AddHttpClient default)
+            // would each hold and refresh their own tokens independently.
+            services.AddSingleton<IAuthenticationService>(sp => new AuthenticationService(
+                sp.GetRequiredService<ILogger<AuthenticationService>>(),
+                sp.GetRequiredService<IConfigurationService>(),
+                CreateLongLivedHttpClient()));
+            services.AddSingleton<ISpotifyService>(sp => new SpotifyService(
+                CreateLongLivedHttpClient(),
+                sp.GetRequiredService<ILogger<SpotifyService>>(),
+                sp.GetRequiredService<IAuthenticationService>()));
+
             services.AddHttpClient<IGithubReleaseService, GithubReleaseService>();
             services.AddSingleton<IRegistryWrapper, RegistryWrapper>();
             services.AddSingleton<IStartupService, StartupService>();
+        }
+
+        /// <summary>
+        /// Creates an HttpClient suitable for singleton services: pooled connections
+        /// are recycled periodically so long-lived clients still pick up DNS changes.
+        /// </summary>
+        /// <returns>A configured HttpClient</returns>
+        private static HttpClient CreateLongLivedHttpClient()
+        {
+            return new HttpClient(new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(15)
+            });
         }
 
         /// <summary>
@@ -152,11 +176,12 @@ namespace BeatBind
         /// <param name="services">The service collection</param>
         private static void ConfigureApplication(IServiceCollection services)
         {
-            // Application Services
-            services.AddTransient<AuthenticationApplicationService>();
-            services.AddTransient<ConfigurationApplicationService>();
-            services.AddTransient<MusicControlApplicationService>();
-            services.AddTransient<HotkeyApplicationService>();
+            // Application Services — singletons so state like the playback cache and
+            // last pre-mute volume is shared by every consumer
+            services.AddSingleton<AuthenticationApplicationService>();
+            services.AddSingleton<ConfigurationApplicationService>();
+            services.AddSingleton<MusicControlApplicationService>();
+            services.AddSingleton<HotkeyApplicationService>();
 
             // MediatR
             services.AddMediatR(cfg =>
@@ -180,7 +205,6 @@ namespace BeatBind
 
             services.AddSingleton<IHotkeyService, HotkeyService>(sp =>
             {
-                var mainForm = sp.GetRequiredService<MainForm>();
                 var logger = sp.GetRequiredService<ILogger<HotkeyService>>();
                 return new HotkeyService(logger);
             });

--- a/src/BeatBind/Program.cs
+++ b/src/BeatBind/Program.cs
@@ -166,7 +166,14 @@ namespace BeatBind
         {
             return new HttpClient(new SocketsHttpHandler
             {
-                PooledConnectionLifetime = TimeSpan.FromMinutes(15)
+                PooledConnectionLifetime = TimeSpan.FromMinutes(15),
+                // Keep the connection to the API warm between hotkey presses so a
+                // press after an idle stretch doesn't pay a new TCP + TLS handshake.
+                // The pings require HTTP/2, which SpotifyService requests per call.
+                PooledConnectionIdleTimeout = TimeSpan.FromMinutes(10),
+                KeepAlivePingDelay = TimeSpan.FromSeconds(30),
+                KeepAlivePingTimeout = TimeSpan.FromSeconds(10),
+                KeepAlivePingPolicy = HttpKeepAlivePingPolicy.Always
             });
         }
 

--- a/src/BeatBind/Program.cs
+++ b/src/BeatBind/Program.cs
@@ -174,7 +174,12 @@ namespace BeatBind
                 KeepAlivePingDelay = TimeSpan.FromSeconds(30),
                 KeepAlivePingTimeout = TimeSpan.FromSeconds(10),
                 KeepAlivePingPolicy = HttpKeepAlivePingPolicy.Always
-            });
+            })
+            {
+                // Hotkey commands serialize behind a lock, so a hung request must
+                // fail fast — the 100s default would freeze all hotkeys for minutes
+                Timeout = TimeSpan.FromSeconds(15)
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Version 2.1.0: faster hotkey response, more resilient Spotify/auth handling, and a contributor-ready repo.

### Performance

- Hotkey commands cache the playback state for 2 seconds with optimistic updates, so play/pause, volume, seek, shuffle, and repeat presses send **one HTTP round trip instead of two** — and rapid presses (e.g. mashing volume-up) compute successive steps locally
- Long-lived HTTP/2 connections with keep-alive pings: a press after an idle stretch no longer pays a fresh TCP + TLS handshake
- 15s `HttpClient` timeout (down from the 100s default) so a hung request can't freeze hotkeys behind the command lock

### Bug fixes

- Play/pause during **ads and podcasts** no longer force-resumes playback (Spotify's nullable `item`/`progress_ms` fields are now handled)
- Devices that don't report a volume (`volume_percent: null` — ads, casting, restricted devices) are no longer treated as volume 0; volume/mute commands safely no-op (`PlaybackState.Volume` is now `int?`)
- Token refresh is serialized, applies a 60s expiry safety margin, retries once on 401, and a transient refresh failure no longer wipes the refresh token (previously bricked the session until restart)
- Re-authentication propagates to the running service immediately via a new `AuthenticationSaved` event — switching Spotify accounts takes effect on the next hotkey press instead of when the old token expires
- An abandoned OAuth attempt (browser closed without authorizing) no longer blocks re-authentication until app restart (5-minute callback timeout + listener cleanup)
- Stale pressed-key state is cleared when the keyboard hook resumes, so hotkeys survive sleep/resume without phantom stuck modifiers
- Hotkey IDs are normalized on config load (heals hand-edited/legacy configs with missing or duplicate IDs); new hotkeys get sequential IDs instead of `Environment.TickCount`
- DI lifetimes corrected: auth-stateful services (`SpotifyService`, `AuthenticationService`) are now singletons instead of transients that each refreshed tokens independently

### Refactoring

- `SpotifyService` centralizes request sending, auth headers, and 401 retry in one helper; JSON parsing uses null-safe helpers throughout
- `MusicControlApplicationService` restructured around small shared helpers (lock scaffold, volume/seek adjustment, cache updates) — duplicated boilerplate across 11 methods is gone
- `ISpotifyService` exposes explicit `SetShuffleAsync`/`SetRepeatAsync`; toggle logic moved up where the cached state lives

### Docs & release readiness

- Version bumped to **2.1.0** (`MainForm.CURRENT_VERSION` + README badge)
- New `CONTRIBUTING.md` (build/test commands, branch model, architecture recipes, common gotchas, release checklist), GitHub issue forms (bug report asks for the log file), and a PR template
- ~30 new or updated tests covering the cache behavior, token edge cases, nullable JSON handling, and account-switch propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)