### PR TITLE
Prune phantom keys stuck by secure desktop transitions

### DIFF
--- a/src/BeatBind.Infrastructure/Services/HotkeyService.cs
+++ b/src/BeatBind.Infrastructure/Services/HotkeyService.cs
@@ -37,6 +37,9 @@ namespace BeatBind.Infrastructure.Services
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern IntPtr GetModuleHandle(string lpModuleName);
 
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
         protected delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
 
         public event EventHandler<Hotkey>? HotkeyPressed;
@@ -213,26 +216,78 @@ namespace BeatBind.Infrastructure.Services
 
                 if (wParam == (IntPtr)WM_KEYDOWN || wParam == (IntPtr)WM_SYSKEYDOWN)
                 {
-                    _pressedKeys.Add(vkCode);
-
-                    // Check if this key press triggers a hotkey
-                    bool hotkeyTriggered = CheckHotkeys();
-
                     // If a hotkey was triggered, suppress the key event from propagating
-                    if (hotkeyTriggered)
+                    if (ProcessKeyDown(vkCode))
                     {
                         return (IntPtr)1;
                     }
                 }
                 else if (wParam == (IntPtr)WM_KEYUP || wParam == (IntPtr)WM_SYSKEYUP)
                 {
-                    _pressedKeys.Remove(vkCode);
-                    ClearInactiveHotkeys();
+                    ProcessKeyUp(vkCode);
                 }
             }
 
             // Allow the key event to propagate if no hotkey was triggered
             return CallNextHookEx(_hookId, nCode, wParam, lParam);
+        }
+
+        /// <summary>
+        /// Records a key press, prunes stale keys, and checks for hotkey matches.
+        /// </summary>
+        /// <param name="vkCode">The virtual key code of the pressed key.</param>
+        /// <returns>True if a hotkey was triggered (the key event should be suppressed); otherwise, false.</returns>
+        protected bool ProcessKeyDown(int vkCode)
+        {
+            PruneReleasedKeys(vkCode);
+            _pressedKeys.Add(vkCode);
+
+            return CheckHotkeys();
+        }
+
+        /// <summary>
+        /// Records a key release and clears hotkeys whose keys are no longer held.
+        /// </summary>
+        /// <param name="vkCode">The virtual key code of the released key.</param>
+        protected void ProcessKeyUp(int vkCode)
+        {
+            _pressedKeys.Remove(vkCode);
+            ClearInactiveHotkeys();
+        }
+
+        /// <summary>
+        /// Removes keys from the pressed set that the OS reports as no longer held.
+        /// Key-up events are lost whenever Windows switches to the secure desktop
+        /// (Win+L lock, Ctrl+Alt+Del, UAC prompts) because low-level hooks receive
+        /// no events there — e.g. the Win key from Win+L would otherwise stay
+        /// "pressed" forever and block all hotkey matching until restart.
+        /// </summary>
+        /// <param name="currentVkCode">The key being processed right now. Excluded from
+        /// pruning: the OS input state is not yet updated for the current event, and
+        /// events this hook suppressed never reach the OS input state at all.</param>
+        private void PruneReleasedKeys(int currentVkCode)
+        {
+            if (_pressedKeys.Count == 0)
+            {
+                return;
+            }
+
+            int removed = _pressedKeys.RemoveWhere(vk => vk != currentVkCode && !IsKeyDownInOS(vk));
+            if (removed > 0)
+            {
+                ClearInactiveHotkeys();
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the OS considers the given key physically held down.
+        /// Virtual so tests can simulate OS key state without P/Invoke.
+        /// </summary>
+        /// <param name="vkCode">The virtual key code to check.</param>
+        /// <returns>True if the key is currently down; otherwise, false.</returns>
+        protected virtual bool IsKeyDownInOS(int vkCode)
+        {
+            return (GetAsyncKeyState(vkCode) & 0x8000) != 0;
         }
 
         /// <summary>

--- a/src/BeatBind.Tests/Infrastructure/Services/HotkeyServiceTests.cs
+++ b/src/BeatBind.Tests/Infrastructure/Services/HotkeyServiceTests.cs
@@ -178,6 +178,97 @@ namespace BeatBind.Tests.Infrastructure.Services
                 Times.Once);
         }
 
+        // Virtual key codes used by the key-simulation tests
+        private const int VkLWin = 0x5B;
+        private const int VkLMenu = 0xA4; // left Alt
+        private const int VkNumPad3 = 0x63;
+
+        // Regression test for the Win+L lock bug: the Win key-down is seen by the
+        // hook, but its key-up happens on the secure desktop where low-level hooks
+        // receive no events. Without pruning, the phantom Win modifier blocks all
+        // hotkey matching until the app is restarted.
+        [Fact]
+        public void Hotkey_AfterKeyUpLostToSecureDesktop_ShouldStillTrigger()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggered = new ManualResetEventSlim(false);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => triggered.Set());
+
+            // Win+L: key-down observed, key-up swallowed by the lock screen
+            service.SimulateKeyDown(VkLWin);
+            service.SimulateLostKeyUp(VkLWin);
+
+            // After unlock, the user presses Alt+NumPad3
+            service.SimulateKeyDown(VkLMenu);
+            var suppressed = service.SimulateKeyDown(VkNumPad3);
+
+            suppressed.Should().BeTrue("the phantom Win key should be pruned so the hotkey matches");
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Hotkey_WithHeldModifier_ShouldNotBePrunedAndShouldTrigger()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggered = new ManualResetEventSlim(false);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => triggered.Set());
+
+            // Normal use: Alt is genuinely held when the main key goes down
+            service.SimulateKeyDown(VkLMenu);
+            var suppressed = service.SimulateKeyDown(VkNumPad3);
+
+            suppressed.Should().BeTrue();
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        }
+
+        // A key-down this hook suppresses never reaches the OS input state, so
+        // GetAsyncKeyState reports it as up while it is physically held. The key
+        // currently being processed must therefore be excluded from pruning.
+        [Fact]
+        public void Hotkey_WhoseKeyDownIsNotReflectedInOsState_ShouldStillTrigger()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggered = new ManualResetEventSlim(false);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => triggered.Set());
+
+            service.SimulateKeyDown(VkLMenu);
+            var suppressed = service.SimulateKeyDownInvisibleToOS(VkNumPad3);
+
+            suppressed.Should().BeTrue("the current key must not be pruned even if the OS state does not show it down");
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Hotkey_AfterMainKeyUpLostToSecureDesktop_ShouldTriggerOnNextPress()
+        {
+            var service = new KeySimulatingHotkeyService(_mockLogger.Object);
+            var triggerCount = 0;
+            var triggered = new SemaphoreSlim(0);
+            service.RegisterHotkey(
+                new Hotkey { Id = 1, Action = HotkeyAction.VolumeDown, KeyCode = VkNumPad3, Modifiers = ModifierKeys.Alt },
+                () => { Interlocked.Increment(ref triggerCount); triggered.Release(); });
+
+            // Hotkey fires, then both key-ups are lost (e.g. locked mid-press)
+            service.SimulateKeyDown(VkLMenu);
+            service.SimulateKeyDown(VkNumPad3);
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            service.SimulateLostKeyUp(VkNumPad3);
+            service.SimulateLostKeyUp(VkLMenu);
+
+            // After unlock the same hotkey is pressed again
+            service.SimulateKeyDown(VkLMenu);
+            service.SimulateKeyDown(VkNumPad3);
+
+            triggered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            triggerCount.Should().Be(2);
+        }
+
         // Testable subclass to bypass P/Invoke
         private class TestableHotkeyService : HotkeyService
         {
@@ -208,6 +299,40 @@ namespace BeatBind.Tests.Infrastructure.Services
                 IsHookInstalled = false;
                 UninstallCallCount++;
             }
+        }
+
+        // Simulates key events and OS key state without P/Invoke. "Lost" key-ups
+        // update the simulated OS state but never reach the hook — exactly what
+        // happens when Windows switches to the secure desktop (Win+L, UAC).
+        private class KeySimulatingHotkeyService : HotkeyService
+        {
+            private readonly HashSet<int> _osKeysDown = new();
+
+            public KeySimulatingHotkeyService(ILogger<HotkeyService> logger) : base(logger) { }
+
+            public bool SimulateKeyDown(int vkCode)
+            {
+                _osKeysDown.Add(vkCode);
+                return ProcessKeyDown(vkCode);
+            }
+
+            // A key-down whose event was suppressed never registers in the OS input state
+            public bool SimulateKeyDownInvisibleToOS(int vkCode)
+            {
+                return ProcessKeyDown(vkCode);
+            }
+
+            // The key is physically released but the hook never sees the key-up event
+            public void SimulateLostKeyUp(int vkCode)
+            {
+                _osKeysDown.Remove(vkCode);
+            }
+
+            protected override bool IsKeyDownInOS(int vkCode) => _osKeysDown.Contains(vkCode);
+
+            protected override IntPtr InstallHook(LowLevelKeyboardProc proc) => new IntPtr(123);
+
+            protected override void UninstallHook(IntPtr hookId) { }
         }
 
         // Always fails to install the hook — used to test error logging in the constructor


### PR DESCRIPTION
Locking with Win+L switches to the secure desktop, where low-level keyboard hooks receive no events — the Win key-up is never seen, so LWin stayed in the pressed-keys set forever and no hotkey could match until restart. Now every key-down prunes keys the OS reports as released (GetAsyncKeyState), which also covers Ctrl+Alt+Del, UAC prompts, fast user switching, and RDP.

Fixes #77

The Fixes #77 line will auto-close the issue when the commit lands on your default branch — since that's main, it'll close when you eventually merge dev → main, not on the push to dev. If you'd rather close it manually after the reporter confirms on beta, change it to Refs #77.